### PR TITLE
feat: Include periods where EH has previously been registered

### DIFF
--- a/source/electrical_heating/contracts/electricity_market__electrical_heating/consumption_metering_point_periods_v1.py
+++ b/source/electrical_heating/contracts/electricity_market__electrical_heating/consumption_metering_point_periods_v1.py
@@ -30,7 +30,7 @@ consumption_metering_point_periods_v1 = t.StructType(
         # States whether the metering point has electrical heating in the period
         # true:  The consumption metering has electrical heating in the stated period
         # false: The consumption metering point was previously marked as having electrical
-        #        heating in the stated period, but this has been corrected.
+        #        heating in the stated period, but this has been corrected
         t.StructField("has_electrical_heating", t.BooleanType(), not nullable),
         #
         # 2 | 3 | 4 | 5 | 6 | 99 | NULL

--- a/source/electrical_heating/contracts/electricity_market__electrical_heating/consumption_metering_point_periods_v1.py
+++ b/source/electrical_heating/contracts/electricity_market__electrical_heating/consumption_metering_point_periods_v1.py
@@ -2,8 +2,7 @@ import pyspark.sql.types as t
 
 nullable = True
 
-# Includes all periods of consumption metering points where electrical heating is registered.
-# Metering point periods where the electrical heating flag is not set must be omitted from the data set.
+# Includes all periods of consumption metering points where electrical heating is - or has been previously - registered.
 #
 # A period is created whenever any of the following transaction types are registered:
 # - CHANGESUP: Leverandørskift (BRS-001)
@@ -27,6 +26,9 @@ consumption_metering_point_periods_v1 = t.StructType(
         #
         # GSRN number
         t.StructField("metering_point_id", t.StringType(), not nullable),
+        #
+        # States whether the metering point has electrical heating in the period
+        t.StructField("has_electrical_heating", t.BooleanType(), not nullable),
         #
         # 2 | 3 | 4 | 5 | 6 | 99 | NULL
         t.StructField("net_settlement_group", t.IntegerType(), not nullable),

--- a/source/electrical_heating/contracts/electricity_market__electrical_heating/consumption_metering_point_periods_v1.py
+++ b/source/electrical_heating/contracts/electricity_market__electrical_heating/consumption_metering_point_periods_v1.py
@@ -28,6 +28,9 @@ consumption_metering_point_periods_v1 = t.StructType(
         t.StructField("metering_point_id", t.StringType(), not nullable),
         #
         # States whether the metering point has electrical heating in the period
+        # true:  The consumption metering has electrical heating in the stated period
+        # false: The consumption metering point was previously marked as having electrical
+        #        heating in the stated period, but this has been corrected.
         t.StructField("has_electrical_heating", t.BooleanType(), not nullable),
         #
         # 2 | 3 | 4 | 5 | 6 | 99 | NULL

--- a/source/electrical_heating/tests/integration_tests/calculation_scenarios/given_a_smoke_test_scenario/when/electricity_market__electrical_heating/consumption_metering_point_periods_v1.csv
+++ b/source/electrical_heating/tests/integration_tests/calculation_scenarios/given_a_smoke_test_scenario/when/electricity_market__electrical_heating/consumption_metering_point_periods_v1.csv
@@ -1,2 +1,2 @@
-metering_point_id;net_settlement_group;settlement_month;period_from_date;period_to_date
-170000000000000201;;1;2024-02-01 23:00:00;2024-03-01 23:00:00
+metering_point_id;has_electrical_heating;net_settlement_group;settlement_month;period_from_date;period_to_date
+170000000000000201;true;;1;2024-02-01 23:00:00;2024-03-01 23:00:00


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

We need to know the metering point periods that must be reset.

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
