### PR TITLE
test: Add ignore_extra_columns_in_actual to sample configuration

### DIFF
--- a/source/capacity_settlement/tests/testsession.local.settings.sample.yml
+++ b/source/capacity_settlement/tests/testsession.local.settings.sample.yml
@@ -19,3 +19,11 @@ scenario_tests:
   # Options: True | False
   # `False` is the default.
   show_actual_and_expected_count: False
+
+  # This setting determines how extra columns in the actual dataframe are handled during comparison.
+  # If set to True, only the columns in the expected dataframe are asserted, and any additional columns
+  # in the actual dataframe are ignored. Columns explicitly marked as [IGNORED] in the expected dataframe
+  # are also excluded from the comparison. If set to False, all columns in both dataframes are asserted.
+  # Options: True | False
+  # `True` is the default.
+  ignore_extra_columns_in_actual: True

--- a/source/electrical_heating/tests/testsession.local.settings.sample.yml
+++ b/source/electrical_heating/tests/testsession.local.settings.sample.yml
@@ -19,3 +19,11 @@ scenario_tests:
   # Options: True | False
   # `False` is the default.
   show_actual_and_expected_count: False
+
+  # This setting determines how extra columns in the actual dataframe are handled during comparison.
+  # If set to True, only the columns in the expected dataframe are asserted, and any additional columns
+  # in the actual dataframe are ignored. Columns explicitly marked as [IGNORED] in the expected dataframe
+  # are also excluded from the comparison. If set to False, all columns in both dataframes are asserted.
+  # Options: True | False
+  # `True` is the default.
+  ignore_extra_columns_in_actual: True

--- a/source/electrical_heating/tests/testsession_configuration.py
+++ b/source/electrical_heating/tests/testsession_configuration.py
@@ -41,7 +41,6 @@ class ScenarioTestsConfiguration:
         self.show_actual_and_expected_count = configuration.get(
             "show_actual_and_expected_count", False
         )
-
         self.ignore_extra_columns_in_actual = configuration.get(
             "ignore_extra_columns_in_actual", True
         )


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

Somehow the ignore_extra_columns_in_actual was not added in a former PR.
This is corrected.

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
