### PR TITLE
chore: bump virtualenv from 20.24.2 to 20.26.6 in /.docker

### DIFF
--- a/.docker/requirements.txt
+++ b/.docker/requirements.txt
@@ -20,7 +20,7 @@ pytest-xdist
 # Packages in Databricks Runtime 15.4 LTS
 azure-core==1.32.0 # issue with 1.30.2 which is the version in Databricks Runtime 15.4 LTS
 python-dateutil==2.8.2
-virtualenv==20.24.2
+virtualenv==20.26.6
 
 # Other packages
 azure-identity==1.17.1


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
