### PR TITLE
refac: Use child_period_from_date and child_period_to_date instead of coupled_date decopled_date

### DIFF
--- a/source/capacity_settlement/src/contracts/electricity_market__capacity_settlement/metering_point_periods_v1.py
+++ b/source/capacity_settlement/src/contracts/electricity_market__capacity_settlement/metering_point_periods_v1.py
@@ -29,12 +29,12 @@ metering_point_periods_v1 = t.StructType(
         # ID of the child metering point, which is of type 'capacity_settlement'
         t.StructField("child_metering_point_id", t.StringType(), not nullable),
         #
-        # The date where the child metering point (of type 'capacity_settlement') was coupled to the parent metering point
+        # The date where the child metering point (of type 'capacity_settlement') was created
         # UTC time
-        t.StructField("coupled_date", t.TimestampType(), not nullable),
+        t.StructField("child_period_from_date", t.TimestampType(), not nullable),
         #
-        # The date where the child metering point (of type 'capacity_settlement') was decoupled from the parent metering point
+        # The date where the child metering point (of type 'capacity_settlement') was closed down
         # UTC time
-        t.StructField("decoupled_date", t.TimestampType(), nullable),
+        t.StructField("child_period_to_date", t.TimestampType(), nullable),
     ]
 )

--- a/source/capacity_settlement/tests/scenario_tests/given_a_smoke_test_scenario/test_scenario.py
+++ b/source/capacity_settlement/tests/scenario_tests/given_a_smoke_test_scenario/test_scenario.py
@@ -1,4 +1,13 @@
 ﻿import pytest
+from pyspark.sql.functions import col, to_timestamp
+from pyspark.sql.types import (
+    TimestampType,
+    DecimalType,
+    StructType,
+    StructField,
+    StringType,
+    IntegerType,
+)
 from testcommon.dataframes import (
     assert_dataframes_and_schemas,
     AssertDataframesConfiguration,
@@ -8,13 +17,44 @@ from testcommon.etl import get_then_names, TestCases
 
 @pytest.mark.parametrize("name", get_then_names())
 def test_case(
+    spark,
     name: str,
     test_cases: TestCases,
     assert_dataframes_configuration: AssertDataframesConfiguration,
 ) -> None:
-    test_case = test_cases[name]
-    assert_dataframes_and_schemas(
-        actual=test_case.actual,
-        expected=test_case.expected,
-        configuration=assert_dataframes_configuration,
+    schema = StructType(
+        [
+            StructField("metering_point_id", StringType(), True),
+            StructField("date", TimestampType(), True),
+            StructField("quantity", IntegerType(), True),
+            StructField("comment", StringType(), True),
+        ]
     )
+
+    raw_df = spark.read.option("timestampFormat", "yyyy-MM-dd'T'HH:mm'Z'").csv(
+        "tmp_measurements.csv", header=True, sep=";", schema=schema
+    )
+    raw_df.printSchema()
+
+    # raw_df = spark.read.csv("tmp_measurements.csv", header=True, sep=";")
+    # raw_df = raw_df.withColumn("date", col("date").cast("timestamp"))
+    raw_df.show()
+    # # raw_df.show()
+    # schema = StructType([StructField("date", StringType(), True)])
+    #
+    # # Create a DataFrame with a single row
+    # data = [("2026-01-08T03:00Z",)]
+    # # data = [("2025-01-09T15:30+02:00",)]
+    # df = spark.createDataFrame(data, schema)
+    # # df = df.withColumn("date", col("date").cast("timestamp"))
+    # df = df.select(to_timestamp(df.date, "yyyy-MM-dd'T'HH:mm'Z'").alias("date"))
+    # df.show()
+
+    # test_case = test_cases[name]
+    # test_case.expected.show()
+    # test_case.actual.show()
+    # assert_dataframes_and_schemas(
+    #     actual=test_case.actual,
+    #     expected=test_case.expected,
+    #     configuration=assert_dataframes_configuration,
+    # )

--- a/source/capacity_settlement/tests/scenario_tests/given_a_smoke_test_scenario/test_scenario.py
+++ b/source/capacity_settlement/tests/scenario_tests/given_a_smoke_test_scenario/test_scenario.py
@@ -1,13 +1,4 @@
 ﻿import pytest
-from pyspark.sql.functions import col, to_timestamp
-from pyspark.sql.types import (
-    TimestampType,
-    DecimalType,
-    StructType,
-    StructField,
-    StringType,
-    IntegerType,
-)
 from testcommon.dataframes import (
     assert_dataframes_and_schemas,
     AssertDataframesConfiguration,
@@ -17,44 +8,13 @@ from testcommon.etl import get_then_names, TestCases
 
 @pytest.mark.parametrize("name", get_then_names())
 def test_case(
-    spark,
     name: str,
     test_cases: TestCases,
     assert_dataframes_configuration: AssertDataframesConfiguration,
 ) -> None:
-    schema = StructType(
-        [
-            StructField("metering_point_id", StringType(), True),
-            StructField("date", TimestampType(), True),
-            StructField("quantity", IntegerType(), True),
-            StructField("comment", StringType(), True),
-        ]
+    test_case = test_cases[name]
+    assert_dataframes_and_schemas(
+        actual=test_case.actual,
+        expected=test_case.expected,
+        configuration=assert_dataframes_configuration,
     )
-
-    raw_df = spark.read.option("timestampFormat", "yyyy-MM-dd'T'HH:mm'Z'").csv(
-        "tmp_measurements.csv", header=True, sep=";", schema=schema
-    )
-    raw_df.printSchema()
-
-    # raw_df = spark.read.csv("tmp_measurements.csv", header=True, sep=";")
-    # raw_df = raw_df.withColumn("date", col("date").cast("timestamp"))
-    raw_df.show()
-    # # raw_df.show()
-    # schema = StructType([StructField("date", StringType(), True)])
-    #
-    # # Create a DataFrame with a single row
-    # data = [("2026-01-08T03:00Z",)]
-    # # data = [("2025-01-09T15:30+02:00",)]
-    # df = spark.createDataFrame(data, schema)
-    # # df = df.withColumn("date", col("date").cast("timestamp"))
-    # df = df.select(to_timestamp(df.date, "yyyy-MM-dd'T'HH:mm'Z'").alias("date"))
-    # df.show()
-
-    # test_case = test_cases[name]
-    # test_case.expected.show()
-    # test_case.actual.show()
-    # assert_dataframes_and_schemas(
-    #     actual=test_case.actual,
-    #     expected=test_case.expected,
-    #     configuration=assert_dataframes_configuration,
-    # )

--- a/source/capacity_settlement/tests/scenario_tests/given_a_smoke_test_scenario/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
+++ b/source/capacity_settlement/tests/scenario_tests/given_a_smoke_test_scenario/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
@@ -1,2 +1,2 @@
-metering_point_id;period_from_date;period_to_date;child_metering_point_id;coupled_date;decoupled_date;#comment
-170000000000000201;2020-01-31T23:00:00Z;;900000000000000001;2024-12-31T23:00:00Z;;
+metering_point_id;period_from_date;period_to_date;child_metering_point_id;child_period_from_date;child_period_to_date
+170000000000000201;2020-01-31T23:00:00Z;;900000000000000001;2024-12-31T23:00:00Z;

--- a/source/capacity_settlement/tests/scenario_tests/wip_change_to_summertime/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
+++ b/source/capacity_settlement/tests/scenario_tests/wip_change_to_summertime/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
@@ -1,2 +1,2 @@
-metering_point_id;period_from_date;period_to_date;child_metering_point_id;coupled_date;decoupled_date
+metering_point_id;period_from_date;period_to_date;child_metering_point_id;child_period_from_date;child_period_to_date
 170000000000000201;2020-01-31T23:00:00Z;;900000000000000001;2024-12-31T23:00:00Z;

--- a/source/capacity_settlement/tests/scenario_tests/wip_change_to_wintertime/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
+++ b/source/capacity_settlement/tests/scenario_tests/wip_change_to_wintertime/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
@@ -1,2 +1,2 @@
-metering_point_id;period_from_date;period_to_date;child_metering_point_id;coupled_date;decoupled_date;#comment
+metering_point_id;period_from_date;period_to_date;child_metering_point_id;child_period_from_date;child_period_to_date;#comment
 170000000000000201;2020-01-31T23:00:00Z;;900000000000000001;2024-12-31T23:00:00Z;;

--- a/source/capacity_settlement/tests/scenario_tests/wip_leap_year_calculation_period/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
+++ b/source/capacity_settlement/tests/scenario_tests/wip_leap_year_calculation_period/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
@@ -1,2 +1,2 @@
-metering_point_id;period_from_date;period_to_date;child_metering_point_id;coupled_date;decoupled_date;#comment
+metering_point_id;period_from_date;period_to_date;child_metering_point_id;child_period_from_date;child_period_to_date;#comment
 170000000000000201;2020-01-31T23:00:00Z;;900000000000000001;2024-12-31T23:00:00Z;;

--- a/source/capacity_settlement/tests/scenario_tests/wip_leap_year_selection_period/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
+++ b/source/capacity_settlement/tests/scenario_tests/wip_leap_year_selection_period/when/electricity_market__capacity_settlement/metering_point_periods_v1.csv
@@ -1,2 +1,2 @@
-metering_point_id;period_from_date;period_to_date;child_metering_point_id;coupled_date;decoupled_date;#comment
+metering_point_id;period_from_date;period_to_date;child_metering_point_id;child_period_from_date;child_period_to_date;#comment
 170000000000000201;2020-01-31 23:00:00;;900000000000000001;2024-12-31 23:00:00;;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

According to SME child_period_from_date/child_period_to_date matcher better with the business process than coupled_date /decopled_date

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
