### PR TITLE
ci: released wheel should be within a  folder

### DIFF
--- a/.github/actions/create-prerelease/action.yml
+++ b/.github/actions/create-prerelease/action.yml
@@ -38,8 +38,8 @@ runs:
     - name: Build ${{ inputs.name }}
       shell: bash
       run: |
-        mkdir -p ${{ env.RELEASE_FOLDER_PATH}}
-        uv build --directory ${{ inputs.path }} --out-dir ${{ inputs.github_workspace }}/${{ env.RELEASE_FOLDER_PATH}}
+        mkdir -p ${{ env.RELEASE_FOLDER_PATH}}/dist
+        uv build --directory ${{ inputs.path }} --out-dir ${{ inputs.github_workspace }}/${{ env.RELEASE_FOLDER_PATH}}/dist
     - name: Copy Container Tests from ${{ inputs.name }}
       shell: bash
       run: |


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->
dh3-environments expects released wheel to be inside a `dist` folder in the zipped release. This PR ensures that this happens. 

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
