### PR TITLE
ci: gh release delete throws when a release does not exist

### DIFF
--- a/.github/actions/promote-prerelease/action.yml
+++ b/.github/actions/promote-prerelease/action.yml
@@ -26,7 +26,11 @@ runs:
         gh release edit ${{ steps.set_release_name.outputs.release_name }} --prerelease=false
 
         echo 'Deleting ${{ inputs.release_name_prefix }}_latest if exists'
-        gh release delete ${{ inputs.release_name_prefix }}_latest --yes
+
+        RELEASE_EXISTS=$(gh release view ${{ inputs.release_name_prefix }}_latest)
+        if ! [ -z "$RELEASE_EXISTS" ]; then
+           gh release delete ${{ inputs.release_name_prefix }}_latest --yes
+        fi
 
         echo 'Creating new ${{ inputs.release_name_prefix }}_latest'
         gh release create ${{ inputs.release_name_prefix }}_latest --title ${{ inputs.release_name_prefix }}_latest --notes "RELEASE_NAME=${{ steps.set_release_name.outputs.release_name }}" --latest


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

CD workflow fails if '{package}_latest' does not exist - it shouldn't.

<img width="753" alt="image" src="https://github.com/user-attachments/assets/a557d13d-72e2-436d-943f-c2e379b4a766" />


## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
