### PR TITLE
ci: fix typo in if condition

### DIFF
--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Create release matrix
         shell: python
-        if: ${{ steps.list_contents.outputs.any_artifact == 'true' }}
+        if: ${{ steps.list_artifacts.outputs.any_artifact == 'true' }}
         id: create_matrix
         run: |
           from pathlib import Path


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->
Fixes a typo in `ci-orchestrator` that meant no release matrix was ever created resulting in the failure of the `create_release` job.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
