### PR TITLE
ci: we no longer prepackage releases

### DIFF
--- a/.github/actions/create-prerelease/action.yml
+++ b/.github/actions/create-prerelease/action.yml
@@ -34,8 +34,8 @@ runs:
         if [ -d ${{ inputs.path }}/dist ]; then
           cp -r ${{ inputs.path }}/dist ${{ env.RELEASE_FOLDER_PATH}}/dist
         fi
-        if [ -d ${{ inputs.path }}/container_tests ]; then
-          cp -r ${{ inputs.path }}/container_tests ${{ env.RELEASE_FOLDER_PATH}}/container_tests
+        if [ -d ${{ inputs.path }}/tests/container_tests ]; then
+          cp -r ${{ inputs.path }}/tests/container_tests ${{ env.RELEASE_FOLDER_PATH}}/container_tests
         fi
     - name: Zip files for ${{ inputs.name }} prerelease
       uses: thedoctor0/zip-release@0.7.6


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Since we no longer prepackage release artifacts, we have to change where we find `container_tests`.

<!-- INSERT DESCRIPTION HERE -->

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
