### PR TITLE
project: add .gitattributes to ensure similar line endings on unix/windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,71 @@
+# Stolen from https://github.com/dotnet/runtime/blob/main/.gitattributes
+
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+*.doc  diff=astextplain
+*.DOC	diff=astextplain
+*.docx	diff=astextplain
+*.DOCX	diff=astextplain
+*.dot	diff=astextplain
+*.DOT	diff=astextplain
+*.pdf	diff=astextplain
+*.PDF	diff=astextplain
+*.rtf	diff=astextplain
+*.RTF	diff=astextplain
+
+*.jpg  	binary
+*.png 	binary
+*.gif 	binary
+
+*.lss 	text
+
+# Force bash scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.in text eol=lf
+*.sh text eol=lf
+
+# Likewise, force cmd and batch scripts to always use crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+*.cs text diff=csharp
+*.vb text
+*.resx text
+*.c text
+*.cpp text
+*.cxx text
+*.h text
+*.hxx text
+*.py text
+*.rb text
+*.java text
+*.html text
+*.htm text
+*.css text
+*.scss text
+*.sass text
+*.less text
+*.js text
+*.lisp text
+*.clj text
+*.sql text
+*.php text
+*.lua text
+*.m text
+*.asm text
+*.erl text
+*.fs text
+*.fsx text
+*.hs text
+
+*.csproj text
+*.vbproj text
+*.fsproj text
+*.dbproj text
+*.sln text eol=crlf
+
+# Set linguist language for .h files explicitly based on
+# https://github.com/github/linguist/issues/1626#issuecomment-401442069
+# this only affects the repo's language statistics
+*.h linguist-language=C

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,7 @@
 # in Unix via a file share from Windows, the scripts will work.
 *.in text eol=lf
 *.sh text eol=lf
+*.tool-versions text eol=lf
 
 # Likewise, force cmd and batch scripts to always use crlf
 *.cmd text eol=crlf


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Some programs do not work with CRLF line-endings. This file ensures consistency in line-endings based on file extensions. I choose to copy the one used in `dotnet`, as this is a system that is actively being developed on both windows and unix platforms and should therefore have experienced the same pains as we are.

<!-- INSERT DESCRIPTION HERE -->

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
