### PR TITLE
chore: Remove deprecated lint.run ruff setting

### DIFF
--- a/.devcontainer/core/devcontainer.json
+++ b/.devcontainer/core/devcontainer.json
@@ -48,7 +48,6 @@
         ],
         "editor.formatOnSave": true,
         "ruff.lineLength": 120,
-        "ruff.lint.run": "onSave",
         "python.terminal.activateEnvInCurrentTerminal": true,
         "python.defaultInterpreterPath": "/home/vscode/.venv/bin/python",
         "python.analysis.typeCheckingMode": "basic",

--- a/templates/devcontainer.json.j2
+++ b/templates/devcontainer.json.j2
@@ -46,18 +46,17 @@
         ],
         "editor.formatOnSave": true,
         "ruff.lineLength": 120,
-        "ruff.lint.run": "onSave",
         "python.terminal.activateEnvInCurrentTerminal": true,
         "python.defaultInterpreterPath": "/home/vscode/.venv/bin/python",
         "python.testing.pytestArgs": [
           "tests"
         ],
-        "python.analysis.include": ["/workspace/source/{{ package_name }}/**/*"], 
+        "python.analysis.include": ["/workspace/source/{{ package_name }}/**/*"],
         "python.venvPath": "/home/vscode/.venv",
         "python.testing.unittestEnabled": false,
         "python.testing.pytestEnabled": true,
         "github.copilot.editor.enableAutoCompletions": true,
-        "python.languageServer": "Pylance", // Use Pylance as the language server        
+        "python.languageServer": "Pylance", // Use Pylance as the language server
         "python.analysis.languageServerMode": "full", // Use the full language server mode
         "python.analysis.autoFormatStrings": true, // Automatically format strings
         "[python]": {


### PR DESCRIPTION
# Description

The following `ruff-lsp` settings are not supported by ruff server:
* lint.run