### PR TITLE
Docs: Fix orchestration type in silver def - and add it to gold, plus some

### DIFF
--- a/docs/gold/table_definitions/gold_measurements.md
+++ b/docs/gold/table_definitions/gold_measurements.md
@@ -4,11 +4,12 @@ This table contains measurements which is presented as one measurement value per
 
 | Column name | Data type | Nullable | Description | Constraints |
 | - | - | - | - | - |
+| orchestration_type | StringType | True | - | Valid values ["submitted", "migration", "electrical_heating", "capacity_settlement"] |
 | metering_point_id | StringType | True | The GSRN number that uniquely identifies the metering point | Exactly 18 digits |
 | observation_time | TimestampType | True | The time when the energy was consumed/produced/exchanged | - |
 | quantity | Decimal(18, 3) | True | The energy quantity. Negative values allowed. May be null when the quality is 'missing' | - |
-| quality | StringType | True | The quality of the energy quantity. | - |
-| metering_point_type | StringType | True | - | - |
+| quality | StringType | True | The quality of the energy quantity | Valid [quality](https://github.com/Energinet-DataHub/opengeh-python-packages/blob/main/src/geh_common/domain/types/quantity_quality.py) values |
+| metering_point_type | StringType | True | - | Valid [metering point type](https://github.com/Energinet-DataHub/opengeh-python-packages/blob/main/src/geh_common/domain/types/metering_point_type.py) values |
 | transaction_id | StringType | True | Contains an ID for the specific time series transaction, provided by the sender or the source system. Uniqueness not guaranteed | - |
 | transaction_creation_datetime | TimestampType | True | Contains the UTC time for when the time series data was persisted in source system | - |
 | created | TimestampType | True | - | - |

--- a/docs/silver/table_definitions/silver_measurements.md
+++ b/docs/silver/table_definitions/silver_measurements.md
@@ -2,14 +2,14 @@
 
 | Column name | Data type | Nullable | Description | Constraints |
 | - | - | - | - | - |
-| orchestration_type | StringType | True | - | valid values ["submitted", "migration", "electrical_heating", "capacity_settlement"] |
+| orchestration_type | StringType | True | - | Valid values ["submitted", "migration"] |
 | orchestration_instance_id | StringType | True | - | - |
 | metering_point_id | StringType | True | The GSRN number that uniquely identifies the metering point | Exactly 18 digits |
 | transaction_id | StringType | True | Contains an ID for the specific time series transaction, provided by the sender or the source system. Uniqueness not guaranteed | - |
 | transaction_creation_datetime | TimestampType | True | Contains the UTC time for when the time series data was persisted in source system | - |
-| metering_point_type | StringType | True | - | [valid metering point types](https://github.com/Energinet-DataHub/opengeh-python-packages/blob/main/src/geh_common/domain/types/metering_point_type.py) |
-| unit | StringType | True | - | valid values ["KWH", "KW", "KVARH", "MWH", "TONNE"], we need to extend this [list](https://github.com/Energinet-DataHub/opengeh-python-packages/blob/main/src/geh_common/domain/types/quantity_unit.py) |
-| resolution | StringType | True | - | valid values ["PT15M", "PT1H", "P1M"], we need to add new file to python packages |
+| metering_point_type | StringType | True | - | Valid [metering point type](https://github.com/Energinet-DataHub/opengeh-python-packages/blob/main/src/geh_common/domain/types/metering_point_type.py) values |
+| unit | StringType | True | - | Valid values ["KWH", "KW", "KVARH", "MWH", "TONNE"], we need to extend this [list](https://github.com/Energinet-DataHub/opengeh-python-packages/blob/main/src/geh_common/domain/types/quantity_unit.py) |
+| resolution | StringType | True | - | Valid values ["PT15M", "PT1H", "P1M"], we need to add new file to python packages |
 | start_datetime | TimestampType | True | - | - |
 | end_datetime | TimestampType | True | - | - |
 | points[*].position | StringType | True | - | - |


### PR DESCRIPTION
# Description
Fix: removes `electrical_heating` and `capacity_settlement` from silver's `orchestration_type`
Adds `orchestration_type` to gold and values for `metering_point_type` and `quality`
Minor text changes.

## References
https://github.com/Energinet-DataHub/team-volt/issues/1069
