### PR TITLE
test: orchestration_instance_id use underscore not dashes

### DIFF
--- a/source/geh_calculated_measurements/tests/capacity_settlement/subsystem_tests/test_capacity_settlement.py
+++ b/source/geh_calculated_measurements/tests/capacity_settlement/subsystem_tests/test_capacity_settlement.py
@@ -57,7 +57,7 @@ class TestCapacitySettlement(unittest.TestCase):
         query = f"""
         AppTraces
         | where Properties["Subsystem"] == 'measurements'
-        | where Properties["orchestration-instance-id"] == '{self.fixture.job_state.calculation_input.orchestration_instance_id}'
+        | where Properties["orchestration_instance_id"] == '{self.fixture.job_state.calculation_input.orchestration_instance_id}'
         """
 
         # Act

--- a/source/geh_calculated_measurements/tests/electrical_heating/subsystem_tests/test_electrical_heating.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/subsystem_tests/test_electrical_heating.py
@@ -53,7 +53,7 @@ class TestElectricalHeating(unittest.TestCase):
         query = f"""
         AppTraces
         | where Properties["Subsystem"] == 'measurements'
-        | where Properties["orchestration-instance-id"] == '{self.fixture.job_state.calculation_input.orchestration_instance_id}'
+        | where Properties["orchestration_instance_id"] == '{self.fixture.job_state.calculation_input.orchestration_instance_id}'
         """
 
         # Act


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
