### PR TITLE
Refactor: Remove unused tests_path fixture from conftest.py files

### DIFF
--- a/source/geh_calculated_measurements/tests/capacity_settlement/conftest.py
+++ b/source/geh_calculated_measurements/tests/capacity_settlement/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests import PROJECT_ROOT, TESTS_ROOT
+from tests import PROJECT_ROOT
 
 
 @pytest.fixture(scope="session")
@@ -12,9 +12,3 @@ def contracts_path() -> str:
     actually located in a file located directly in the tests folder.
     """
     return f"{PROJECT_ROOT}/src/geh_calculated_measurements/capacity_settlement/contracts"
-
-
-@pytest.fixture(scope="session")
-def tests_path() -> str:
-    """Returns the tests folder path."""
-    return (TESTS_ROOT / "capacity_settlement").as_posix()

--- a/source/geh_calculated_measurements/tests/capacity_settlement/job_tests/conftest.py
+++ b/source/geh_calculated_measurements/tests/capacity_settlement/job_tests/conftest.py
@@ -11,11 +11,12 @@ from geh_calculated_measurements.capacity_settlement.infrastructure.measurements
 )
 from geh_calculated_measurements.common.domain import calculated_measurements_schema
 from geh_calculated_measurements.common.infrastructure import CalculatedMeasurementsInternalDatabaseDefinition
+from tests import TESTS_ROOT
 
 
 @pytest.fixture(scope="session")
-def test_files_folder_path(tests_path: str) -> str:
-    return f"{tests_path}/job_tests/test_files"
+def test_files_folder_path() -> str:
+    return (TESTS_ROOT / "capacity_settlement" / "job_tests" / "test_files").as_posix()
 
 
 @pytest.fixture(scope="session")

--- a/source/geh_calculated_measurements/tests/data_products/conftest.py
+++ b/source/geh_calculated_measurements/tests/data_products/conftest.py
@@ -11,7 +11,7 @@ from geh_calculated_measurements.common.domain.model import calculated_measureme
 from geh_calculated_measurements.common.infrastructure import CalculatedMeasurementsDatabaseDefinition
 from geh_calculated_measurements.database_migrations.migrations_runner import migrate
 from geh_calculated_measurements.database_migrations.settings.catalog_settings import CatalogSettings
-from tests import PROJECT_ROOT, TESTS_ROOT
+from tests import PROJECT_ROOT
 from tests.testsession_configuration import TestSessionConfiguration
 
 
@@ -22,12 +22,6 @@ def clear_cache(spark: SparkSession) -> Generator[None, None, None]:
     """
     yield
     spark.catalog.clearCache()
-
-
-@pytest.fixture(scope="session")
-def tests_path() -> str:
-    """Returns the tests folder path."""
-    return (TESTS_ROOT / "data_products").as_posix()
 
 
 @pytest.fixture(scope="session")

--- a/source/geh_calculated_measurements/tests/electrical_heating/conftest.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/conftest.py
@@ -4,7 +4,7 @@ from typing import Generator
 import pytest
 from pyspark.sql import SparkSession
 
-from tests import PROJECT_ROOT, TESTS_ROOT
+from tests import PROJECT_ROOT
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -14,12 +14,6 @@ def clear_cache(spark: SparkSession) -> Generator[None, None, None]:
     """
     yield
     spark.catalog.clearCache()
-
-
-@pytest.fixture(scope="session")
-def tests_path() -> str:
-    """Returns the tests folder path."""
-    return (TESTS_ROOT / "electrical_heating").as_posix()
 
 
 @pytest.fixture(scope="session")

--- a/source/geh_calculated_measurements/tests/electrical_heating/job_tests/conftest.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/job_tests/conftest.py
@@ -39,7 +39,7 @@ def seed_gold_table(spark: SparkSession, test_files_folder_path: str) -> None:
 
 
 @pytest.fixture(scope="session")
-def create_calculated_measurements_table(spark: SparkSession, test_files_folder_path: str) -> None:
+def create_calculated_measurements_table(spark: SparkSession) -> None:
     create_database(spark, CalculatedMeasurementsInternalDatabaseDefinition.DATABASE_NAME)
 
     create_table(
@@ -52,7 +52,7 @@ def create_calculated_measurements_table(spark: SparkSession, test_files_folder_
 
 
 @pytest.fixture(scope="session")
-def job_environment_variables(test_files_folder_path) -> dict:
+def job_environment_variables(test_files_folder_path: str) -> dict:
     return {
         "CATALOG_NAME": "spark_catalog",
         "TIME_ZONE": "Europe/Copenhagen",

--- a/source/geh_calculated_measurements/tests/electrical_heating/job_tests/conftest.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/job_tests/conftest.py
@@ -9,11 +9,12 @@ from geh_calculated_measurements.electrical_heating.infrastructure import (
     MeasurementsGoldDatabaseDefinition,
     electrical_heating_v1,
 )
+from tests import TESTS_ROOT
 
 
 @pytest.fixture(scope="session")
-def test_files_folder_path(tests_path: str) -> str:
-    return f"{tests_path}/job_tests/test_files"
+def test_files_folder_path() -> str:
+    return (TESTS_ROOT / "electrical_heating" / "job_tests" / "test_files").as_posix()
 
 
 @pytest.fixture(scope="session")

--- a/source/geh_calculated_measurements/tests/missing_measurements_log/conftest.py
+++ b/source/geh_calculated_measurements/tests/missing_measurements_log/conftest.py
@@ -3,7 +3,7 @@ from typing import Generator
 import pytest
 from pyspark.sql import SparkSession
 
-from tests import PROJECT_ROOT, TESTS_ROOT
+from tests import PROJECT_ROOT
 
 CONTAINER_NAME = "missing_measurements_log"
 
@@ -15,12 +15,6 @@ def clear_cache(spark: SparkSession) -> Generator[None, None, None]:
     """
     yield
     spark.catalog.clearCache()
-
-
-@pytest.fixture(scope="session")
-def tests_path() -> str:
-    """Returns the tests folder path."""
-    return (TESTS_ROOT / CONTAINER_NAME).as_posix()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Eliminate the unused `tests_path` fixture from multiple `conftest.py` files to streamline the test configuration. This change enhances code clarity and maintainability.