### PR TITLE
chore: add logging to migration start

### DIFF
--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -42,8 +42,19 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/python-uv-ci.yml@v14
     with:
       packages_directory: source
-      pytest_addopts: --ignore-glob 'tests/subsystem_tests/**'
+      pytest_addopts: --ignore-glob 'tests/subsystem_tests/**' --ignore-glob 'tests/integration/**'
       create_subsystem_release: true
+  ci_reusable_integration:
+    uses: Energinet-DataHub/.github/.github/workflows/python-uv-ci.yml@v14
+    with:
+      packages_directory: source
+      tests_directory: tests/integration
+      create_subsystem_release: true
+      environment: AzureAuth
+      azure_tenant_id: ${{ vars.integration_test_azure_tenant_id }}
+      azure_subscription_id: ${{ vars.integration_test_azure_subscription_id }}
+      azure_spn_id: ${{ vars.integration_test_azure_spn_id_oidc }}
+      azure_keyvault_url: ${{ vars.integration_test_azure_keyvault_url }}
 
   #
   # Dotnet CI

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/database_migrations/entry_point.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/database_migrations/entry_point.py
@@ -1,6 +1,15 @@
+from geh_common.telemetry.logger import Logger
+from geh_common.telemetry.logging_configuration import LoggingSettings, configure_logging
+
 import geh_calculated_measurements.database_migrations.migrations_runner as migrations_runner
 
 
 def migrate() -> None:
     """Entry point for the database migrations."""
+    log_settings = LoggingSettings(subsystem="measurements", cloud_role_name="dbr-calculated-measurements")
+    configure_logging(logging_settings=log_settings)
+
+    log = Logger(__name__)
+    log.info(f"Initializing migrations with:\nLogging Settings: {log_settings}")
+
     migrations_runner.migrate()

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/database_migrations/migrations_runner.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/database_migrations/migrations_runner.py
@@ -2,6 +2,8 @@ from geh_common.migrations import (
     SparkSqlMigrationsConfiguration,
     migration_pipeline,
 )
+from geh_common.telemetry.decorators import start_trace
+from geh_common.telemetry.logger import Logger
 
 import geh_calculated_measurements.database_migrations.substitutions as substitutions
 from geh_calculated_measurements.database_migrations.database_definitions import (
@@ -10,19 +12,20 @@ from geh_calculated_measurements.database_migrations.database_definitions import
 from geh_calculated_measurements.database_migrations.settings.catalog_settings import CatalogSettings
 
 
+@start_trace()
 def migrate() -> None:
-    spark_sql_migrations_configuration = _configure_spark_sql_migrations()
-    migration_pipeline.migrate(spark_sql_migrations_configuration)
-
-
-def _configure_spark_sql_migrations() -> SparkSqlMigrationsConfiguration:
+    log = Logger(__name__)
+    catalog_settings = CatalogSettings()
     substitution_variables = substitutions.substitutions()
-    catalog_name = CatalogSettings().catalog_name  # type: ignore
+    log.info(
+        f"Initializing migrations with:\nCatalog Settings: {catalog_settings}\nSubstitution Variables: {substitution_variables}"
+    )
 
-    return SparkSqlMigrationsConfiguration(
+    spark_sql_migrations_configuration = SparkSqlMigrationsConfiguration(
         migration_schema_name=MeasurementsCalculatedInternalDatabaseDefinition.measurements_calculated_internal_database,
         migration_table_name=MeasurementsCalculatedInternalDatabaseDefinition.executed_migrations_table_name,
         migration_scripts_folder_path="geh_calculated_measurements.database_migrations.migration_scripts",
         substitution_variables=substitution_variables,
-        catalog_name=catalog_name,
+        catalog_name=catalog_settings.catalog_name,
     )
+    migration_pipeline.migrate(spark_sql_migrations_configuration)

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/testing/utilities/create_azure_log_query_runner.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/testing/utilities/create_azure_log_query_runner.py
@@ -1,0 +1,50 @@
+import os
+from typing import Callable
+
+import pytest
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.secrets import SecretClient
+from azure.monitor.query import LogsQueryStatus
+
+from geh_calculated_measurements.testing.utilities.log_query_client_wrapper import LogQueryClientWrapper
+
+
+def create_azure_log_query_runner(monkeypatch: pytest.MonkeyPatch) -> Callable[[str, int], LogsQueryStatus]:
+    """Create a function that can be used to run an Azure Log Analytics query and wait for the result.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): The monkeypatch fixture.
+
+    Returns:
+        Callable[[str, int], LogsQueryStatus]: A function that can be used to run an Azure Log Analytics query and wait for the result.
+            The function takes two arguments: the query to run and the timeout in minutes.
+    """
+    credentials = DefaultAzureCredential()
+    azure_logs_query_client = LogQueryClientWrapper(credentials)
+
+    azure_keyvault_url = os.getenv("AZURE_KEYVAULT_URL")
+    assert azure_keyvault_url is not None, f"The Azure Key Vault URL cannot be empty: {azure_keyvault_url}"
+    secret_client = SecretClient(vault_url=azure_keyvault_url, credential=credentials)
+    workspace_id = secret_client.get_secret("AZURE-LOGANALYTICS-WORKSPACE-ID").value
+    if workspace_id is None:
+        raise ValueError("The Azure log analytics workspace ID cannot be empty.")
+    application_insights_connection_string = secret_client.get_secret("AZURE-APPINSIGHTS-CONNECTIONSTRING").value
+    if application_insights_connection_string is None:
+        raise ValueError("The Azure Application Insights connection string cannot be empty.")
+
+    monkeypatch.setenv("CATALOG_NAME", "spark_catalog")
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", application_insights_connection_string)
+
+    def query_client(query: str, timeout_minutes: int = 15):
+        """Run an Azure Log Analytics query and wait for the result.
+
+        Args:
+            query (str): The query to run.
+            timeout_minutes (int, optional): The timeout in minutes. Defaults to 15.
+
+        Returns:
+            LogsQueryStatus: The status of the query.
+        """
+        return azure_logs_query_client.wait_for_condition(workspace_id, query.strip(), timespan_minutes=timeout_minutes)
+
+    return query_client

--- a/source/geh_calculated_measurements/tests/__init__.py
+++ b/source/geh_calculated_measurements/tests/__init__.py
@@ -2,3 +2,12 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent
 TESTS_ROOT = PROJECT_ROOT / "tests"
+
+
+def create_job_environment_variables(eletricity_market_path: str = "some_path") -> dict:
+    return {
+        "CATALOG_NAME": "spark_catalog",
+        "TIME_ZONE": "Europe/Copenhagen",
+        "ELECTRICITY_MARKET_DATA_PATH": eletricity_market_path,
+        "APPLICATIONINSIGHTS_CONNECTION_STRING": "some_connection_string",
+    }

--- a/source/geh_calculated_measurements/tests/capacity_settlement/capacity_settlement_tests/application/job_args/test_capacity_settlement_job_args.py
+++ b/source/geh_calculated_measurements/tests/capacity_settlement/capacity_settlement_tests/application/job_args/test_capacity_settlement_job_args.py
@@ -1,13 +1,11 @@
+import os
+import sys
 import uuid
-from unittest.mock import patch
-
-import pytest
 
 from geh_calculated_measurements.capacity_settlement.application.capacity_settlement_args import (
     CapacitySettlementArgs,
 )
-from tests import PROJECT_ROOT
-from tests.capacity_settlement.job_tests import create_job_environment_variables
+from tests import PROJECT_ROOT, create_job_environment_variables
 
 _CONTRACTS_PATH = f"{PROJECT_ROOT}/src/geh_calculated_measurements/capacity_settlement/contracts/"
 
@@ -26,31 +24,16 @@ def _get_contract_parameters(filename: str) -> list[str]:
         return list(filter(lambda line: not line.startswith("#") and len(line) > 0, lines))
 
 
-@pytest.fixture(scope="session")
-def contract_parameters() -> list[str]:
-    job_parameters = _get_contract_parameters(f"{_CONTRACTS_PATH}/parameters-reference.txt")
-
-    return job_parameters
-
-
-@pytest.fixture(scope="session")
-def sys_argv_from_contract(
-    contract_parameters: list[str],
-) -> list[str]:
-    return ["dummy_script_name"] + contract_parameters
-
-
-def test_when_parameters__parses_parameters_from_contract(
-    sys_argv_from_contract: list[str],
-) -> None:
+def test_when_parameters__parses_parameters_from_contract(monkeypatch) -> None:
     """
     This test ensures that the job accepts
     the arguments that are provided by the client.
     """
     # Arrange
-    with patch("sys.argv", sys_argv_from_contract):
-        with patch.dict("os.environ", create_job_environment_variables()):
-            actual_args = CapacitySettlementArgs()
+    sys_args = ["dummy_script_name"] + _get_contract_parameters(f"{_CONTRACTS_PATH}/parameters-reference.txt")
+    monkeypatch.setattr(sys, "argv", sys_args)
+    monkeypatch.setattr(os, "environ", create_job_environment_variables())
+    actual_args = CapacitySettlementArgs()
 
     # Assert
     assert actual_args.orchestration_instance_id == DEFAULT_ORCHESTRATION_INSTANCE_ID

--- a/source/geh_calculated_measurements/tests/capacity_settlement/job_tests/__init__.py
+++ b/source/geh_calculated_measurements/tests/capacity_settlement/job_tests/__init__.py
@@ -1,11 +1,3 @@
 from tests import TESTS_ROOT
 
 TEST_FILES_FOLDER_PATH = (TESTS_ROOT / "capacity_settlement" / "job_tests" / "test_files").as_posix()
-
-
-def create_job_environment_variables() -> dict:
-    return {
-        "CATALOG_NAME": "spark_catalog",
-        "TIME_ZONE": "Europe/Copenhagen",
-        "ELECTRICITY_MARKET_DATA_PATH": TEST_FILES_FOLDER_PATH,
-    }

--- a/source/geh_calculated_measurements/tests/capacity_settlement/job_tests/test_capacity_settlement_job.py
+++ b/source/geh_calculated_measurements/tests/capacity_settlement/job_tests/test_capacity_settlement_job.py
@@ -1,36 +1,37 @@
+import os
+import sys
 import uuid
 from typing import Any
-from unittest.mock import patch
 
 from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 
 from geh_calculated_measurements.capacity_settlement.entry_point import execute
 from geh_calculated_measurements.common.infrastructure import CalculatedMeasurementsInternalDatabaseDefinition
-from tests.capacity_settlement.job_tests import create_job_environment_variables
-
-
-def _get_job_parameters(orchestration_instance_id: str) -> list[str]:
-    return [
-        "dummy_script_name",
-        f"--orchestration-instance-id={orchestration_instance_id}",
-        "--calculation-year=2026",
-        "--calculation-month=1",
-    ]
+from tests import create_job_environment_variables
+from tests.capacity_settlement.job_tests import TEST_FILES_FOLDER_PATH
 
 
 def test_execute(
-    spark: SparkSession,
-    gold_table_seeded: Any,
-    calculated_measurements_table_created: Any,
+    spark: SparkSession, gold_table_seeded: Any, calculated_measurements_table_created: Any, dummy_logging, monkeypatch
 ) -> None:
     # Arrange
     orchestration_instance_id = str(uuid.uuid4())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "dummy_script_name",
+            f"--orchestration-instance-id={orchestration_instance_id}",
+            "--calculation-year=2026",
+            "--calculation-month=1",
+        ],
+    )
+    monkeypatch.setattr(os, "environ", create_job_environment_variables(str(TEST_FILES_FOLDER_PATH)))
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "some_connection_string")
 
     # Act
-    with patch("sys.argv", _get_job_parameters(orchestration_instance_id)):
-        with patch.dict("os.environ", create_job_environment_variables()):
-            execute()
+    execute()
 
     # Assert
     actual_calculated_measurements = spark.read.table(

--- a/source/geh_calculated_measurements/tests/data_products/contract_and_database_are_equal/test_contract_and_database_equality.py
+++ b/source/geh_calculated_measurements/tests/data_products/contract_and_database_are_equal/test_contract_and_database_equality.py
@@ -1,18 +1,23 @@
+import os
+
+import pytest
 from geh_common.testing.dataframes import AssertDataframesConfiguration, assert_contract
 from pyspark.sql import SparkSession
 
 from geh_calculated_measurements.common.infrastructure import CalculatedMeasurementsDatabaseDefinition
 from geh_calculated_measurements.contracts.data_products import hourly_calculated_measurements_v1
 from geh_calculated_measurements.database_migrations.settings.catalog_settings import CatalogSettings
+from tests import create_job_environment_variables
 
 
 def test_contract_and_schema_are_equal(
     migrations_executed: None,
-    patch_environment: None,
     assert_dataframes_configuration: AssertDataframesConfiguration,
     spark: SparkSession,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Arrange
+    monkeypatch.setattr(os, "environ", create_job_environment_variables())
     view_name = CalculatedMeasurementsDatabaseDefinition.HOURLY_CALCULATED_MEASUREMENTS_VIEW_NAME
     database = CalculatedMeasurementsDatabaseDefinition.DATABASE_NAME
     catalog = CatalogSettings().catalog_name

--- a/source/geh_calculated_measurements/tests/data_products/given_calculated_measurements/test_scenario.py
+++ b/source/geh_calculated_measurements/tests/data_products/given_calculated_measurements/test_scenario.py
@@ -1,16 +1,21 @@
+import os
+
 import pytest
 from geh_common.testing.dataframes import AssertDataframesConfiguration, assert_dataframes_and_schemas
 from geh_common.testing.scenario_testing import TestCases, get_then_names
+
+from tests import create_job_environment_variables
 
 
 @pytest.mark.parametrize("name", get_then_names())
 def test_case(
     migrations_executed: None,
-    patch_environment,
     test_cases: TestCases,
     assert_dataframes_configuration: AssertDataframesConfiguration,
     name: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(os, "environ", create_job_environment_variables())
     test_case = test_cases[name]
 
     assert_dataframes_and_schemas(

--- a/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/application/test_electrical_heating_job_args.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/application/test_electrical_heating_job_args.py
@@ -1,18 +1,17 @@
+import os
+import sys
 import uuid
-from unittest.mock import patch
-
-import pytest
 
 from geh_calculated_measurements.electrical_heating.application.electrical_heating_args import (
     ElectricalHeatingArgs,
 )
-from tests import PROJECT_ROOT
+from tests import PROJECT_ROOT, create_job_environment_variables
 
 _CONTRACTS_PATH = (PROJECT_ROOT / "src" / "geh_calculated_measurements" / "electrical_heating" / "contracts").as_posix()
 
 DEFAULT_ORCHESTRATION_INSTANCE_ID = uuid.UUID("12345678-9fc8-409a-a169-fbd49479d711")
-DEFAULT_TIME_ZONE = "some_time_zone"
-DEFAULT_CATALOG_NAME = "some_catalog"
+DEFAULT_TIME_ZONE = "Europe/Copenhagen"
+DEFAULT_CATALOG_NAME = "spark_catalog"
 
 
 def _get_contract_parameters(filename: str) -> list[str]:
@@ -23,38 +22,16 @@ def _get_contract_parameters(filename: str) -> list[str]:
         return list(filter(lambda line: not line.startswith("#") and len(line) > 0, lines))
 
 
-@pytest.fixture(scope="session")
-def contract_parameters() -> list[str]:
-    job_parameters = _get_contract_parameters(f"{_CONTRACTS_PATH}/parameters-reference.txt")
-    return job_parameters
-
-
-@pytest.fixture(scope="session")
-def sys_argv_from_contract(
-    contract_parameters: list[str],
-) -> list[str]:
-    return ["dummy_script_name"] + contract_parameters
-
-
-def _create_job_environment_variables() -> dict:
-    return {
-        "CATALOG_NAME": "some_catalog",
-        "TIME_ZONE": "some_time_zone",
-        "ELECTRICITY_MARKET_DATA_PATH": "some_path",
-    }
-
-
-def test_when_parameters__parses_parameters_from_contract(
-    sys_argv_from_contract: list[str],
-) -> None:
+def test_when_parameters__parses_parameters_from_contract(monkeypatch) -> None:
     """
     This test ensures that the job accepts
     the arguments that are provided by the client.
     """
     # Arrange
-    with patch("sys.argv", sys_argv_from_contract):
-        with patch.dict("os.environ", _create_job_environment_variables()):
-            actual_args = ElectricalHeatingArgs()
+    sys_args = ["dummy_script_name"] + _get_contract_parameters(f"{_CONTRACTS_PATH}/parameters-reference.txt")
+    monkeypatch.setattr(sys, "argv", sys_args)
+    monkeypatch.setattr(os, "environ", create_job_environment_variables())
+    actual_args = ElectricalHeatingArgs()
 
     # Assert
     assert actual_args.orchestration_instance_id == DEFAULT_ORCHESTRATION_INSTANCE_ID

--- a/source/geh_calculated_measurements/tests/electrical_heating/job_tests/test_electrical_heating_job.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/job_tests/test_electrical_heating_job.py
@@ -1,6 +1,7 @@
+import os
+import sys
 import uuid
 from typing import Any
-from unittest.mock import patch
 
 from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
@@ -9,30 +10,24 @@ from geh_calculated_measurements.common.infrastructure import (
     CalculatedMeasurementsInternalDatabaseDefinition,
 )
 from geh_calculated_measurements.electrical_heating.entry_point import execute
+from tests import create_job_environment_variables
 from tests.electrical_heating.job_tests import get_test_files_folder_path
-
-
-def _create_job_environment_variables() -> dict:
-    return {
-        "CATALOG_NAME": "spark_catalog",
-        "TIME_ZONE": "Europe/Copenhagen",
-        "ELECTRICITY_MARKET_DATA_PATH": get_test_files_folder_path(),
-    }
 
 
 def test_execute(
     spark: SparkSession,
     gold_table_seeded: Any,  # Used implicitly
     calculated_measurements_table_created: Any,  # Used implicitly
+    dummy_logging: Any,  # Used implicitly
+    monkeypatch,
 ) -> None:
     # Arrange
     orchestration_instance_id = str(uuid.uuid4())
-    sys_argv = ["dummy_script_name", "--orchestration-instance-id", orchestration_instance_id]
+    monkeypatch.setattr(sys, "argv", ["dummy_script_name", "--orchestration-instance-id", orchestration_instance_id])
+    monkeypatch.setattr(os, "environ", create_job_environment_variables(get_test_files_folder_path()))
 
     # Act
-    with patch("sys.argv", sys_argv):
-        with patch.dict("os.environ", _create_job_environment_variables()):
-            execute()
+    execute()
 
     # Assert
     actual = spark.read.table(

--- a/source/geh_calculated_measurements/tests/integration/database_migrations/test_migrate.py
+++ b/source/geh_calculated_measurements/tests/integration/database_migrations/test_migrate.py
@@ -1,0 +1,50 @@
+from geh_calculated_measurements.common.infrastructure.calculated_measurements.database_definitions import (
+    CalculatedMeasurementsDatabaseDefinition,
+)
+from geh_calculated_measurements.database_migrations.database_definitions import (
+    MeasurementsCalculatedInternalDatabaseDefinition,
+)
+from geh_calculated_measurements.database_migrations.entry_point import migrate
+from geh_calculated_measurements.testing.utilities.create_azure_log_query_runner import (
+    LogsQueryStatus,
+    create_azure_log_query_runner,
+)
+
+
+def test__when_running_migrate__then_log_is_produced(spark, monkeypatch):
+    # Arrange
+    azure_query_runnner = create_azure_log_query_runner(monkeypatch)
+    timeout_minutes = 15
+    dbs = [
+        MeasurementsCalculatedInternalDatabaseDefinition.measurements_calculated_internal_database,
+        CalculatedMeasurementsDatabaseDefinition.DATABASE_NAME,
+    ]
+    for db in dbs:
+        spark.sql(f"CREATE DATABASE IF NOT EXISTS {db}")
+
+    # Act
+    expected_log_messages = [
+        "Initializing migrations with:\\nLogging Settings:",
+        "Initializing migrations with:\\nCatalog Settings:",
+    ]
+    migrate()
+
+    # Assert
+    for message in expected_log_messages:
+        query = f"""
+            AppTraces
+            | where Properties.Subsystem == "measurements"
+            | where AppRoleName == "dbr-calculated-measurements"
+            | where Message startswith_cs "{message}"
+            | where TimeGenerated > ago({timeout_minutes}m)
+        """
+
+        query_result = azure_query_runnner(query, timeout_minutes=timeout_minutes)
+        assert query_result.status == LogsQueryStatus.SUCCESS, f"The query did not complete successfully:\n{query}"
+        assert query_result.tables[0].rows, (
+            f"No logs were found for the given query:\n{query}\n---\n{query_result.tables}"
+        )
+
+    # Cleanup
+    for db in dbs:
+        spark.sql(f"DROP DATABASE IF EXISTS {db} CASCADE")

--- a/source/geh_calculated_measurements/tests/net_consumption_group_6/job_tests/__init__.py
+++ b/source/geh_calculated_measurements/tests/net_consumption_group_6/job_tests/__init__.py
@@ -1,12 +1,3 @@
 from tests import TESTS_ROOT
 
 TEST_FILES_FOLDER_PATH = (TESTS_ROOT / "net_consumption_group_6" / "job_tests" / "test_files").as_posix()
-
-
-def create_job_environment_variables() -> dict[str, str]:
-    return {
-        "CATALOG_NAME": "spark_catalog",
-        "TIME_ZONE": "Europe/Copenhagen",
-        "ELECTRICITY_MARKET_DATA_PATH": TEST_FILES_FOLDER_PATH,
-        "APPLICATIONINSIGHTS_CONNECTION_STRING": "some-connection-string",
-    }

--- a/source/geh_calculated_measurements/tests/net_consumption_group_6/job_tests/test_net_consumption_group_6_job.py
+++ b/source/geh_calculated_measurements/tests/net_consumption_group_6/job_tests/test_net_consumption_group_6_job.py
@@ -9,16 +9,7 @@ from pyspark.sql import functions as F
 from geh_calculated_measurements.common.domain import ContractColumnNames
 from geh_calculated_measurements.common.infrastructure import CalculatedMeasurementsInternalDatabaseDefinition
 from geh_calculated_measurements.net_consumption_group_6.entry_point import execute
-from tests.net_consumption_group_6.job_tests import create_job_environment_variables
-
-
-def _create_job_parameters(orchestration_instance_id: str) -> list[str]:
-    return [
-        "dummy_script_name",
-        f"--orchestration-instance-id={orchestration_instance_id}",
-        "--calculation-year=2026",
-        "--calculation-month=1",
-    ]
+from tests import create_job_environment_variables
 
 
 def test_execute(
@@ -27,8 +18,13 @@ def test_execute(
 ) -> None:
     # Arrange
     orchestration_instance_id = str(uuid.uuid4())
-
-    monkeypatch.setattr(sys, "argv", _create_job_parameters(orchestration_instance_id))
+    sys_args = [
+        "dummy_script_name",
+        f"--orchestration-instance-id={orchestration_instance_id}",
+        "--calculation-year=2026",
+        "--calculation-month=1",
+    ]
+    monkeypatch.setattr(sys, "argv", sys_args)
     monkeypatch.setattr(os, "environ", create_job_environment_variables())
 
     # Act


### PR DESCRIPTION
# Description

- Made a new folder called `integration` for tests that require the integration test environment
- Removed session-scoped `dummy_logging` - this must now be used explicitly.
- Removed a various unnecessary fixtures around the code base
- Changed `scenario_parameters.yml` values to follow contracts

Sub task of https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/586

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
