### PR TITLE
Refactor measurement schemas and imports

### DIFF
--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/__init__.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/__init__.py
@@ -1,13 +1,11 @@
-from .model.calculations import Calculations, calculations_schema
+from .model.calculations import Calculations
 from .model.metering_point_periods import MeteringPointPeriods
-from .model.ten_largest_quantities import TenLargestQuantities, ten_largest_quantities_schema
+from .model.ten_largest_quantities import TenLargestQuantities
 from .model.time_series_points import TimeSeriesPoints
 
 __all__ = [
     "TimeSeriesPoints",
     "MeteringPointPeriods",
     "TenLargestQuantities",
-    "ten_largest_quantities_schema",
     "Calculations",
-    "calculations_schema",
 ]

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/model/calculations.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/model/calculations.py
@@ -11,24 +11,23 @@ class Calculations(DataFrameWrapper):
     def __init__(self, df: DataFrame):
         super().__init__(
             df=df,
-            schema=calculations_schema,
+            schema=Calculations.schema,
             ignore_nullability=True,
         )
 
-
-calculations_schema = T.StructType(
-    [
-        #
-        # ID of the orchestration that initiated the calculation job
-        T.StructField(ContractColumnNames.orchestration_instance_id, T.StringType(), not nullable),
-        #
-        # Calculation year
-        T.StructField("calculation_year", T.IntegerType(), not nullable),
-        #
-        # Calculation month
-        T.StructField("calculation_month", T.IntegerType(), not nullable),
-        #
-        # Execution time of the calculation
-        T.StructField("execution_time", T.TimestampType(), not nullable),
-    ]
-)
+    schema = T.StructType(
+        [
+            #
+            # ID of the orchestration that initiated the calculation job
+            T.StructField(ContractColumnNames.orchestration_instance_id, T.StringType(), not nullable),
+            #
+            # Calculation year
+            T.StructField("calculation_year", T.IntegerType(), not nullable),
+            #
+            # Calculation month
+            T.StructField("calculation_month", T.IntegerType(), not nullable),
+            #
+            # Execution time of the calculation
+            T.StructField("execution_time", T.TimestampType(), not nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/model/metering_point_periods.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/model/metering_point_periods.py
@@ -13,36 +13,35 @@ class MeteringPointPeriods(DataFrameWrapper):
     def __init__(self, df: DataFrame):
         super().__init__(
             df,
-            metering_point_periods_v1,
+            MeteringPointPeriods.schema,
             # We ignore_nullability because it has turned out to be too hard and even possibly
             # introducing more errors than solving in order to stay in exact sync with the
             # logically correct schema.
             ignore_nullability=True,
         )
 
-
-metering_point_periods_v1 = T.StructType(
-    [
-        # ID of the consumption metering point (parent)
-        T.StructField(ContractColumnNames.metering_point_id, T.StringType(), not nullable),
-        #
-        # Date when the consumption metering is either (a) entering 'connected'/'disconnected' first time or (b) move-in has occurred.
-        # UTC time
-        T.StructField(ContractColumnNames.period_from_date, T.TimestampType(), not nullable),
-        #
-        # Date when the consumption metering point is closed down or a move-in has occurred.
-        # UTC time
-        T.StructField(ContractColumnNames.period_to_date, T.TimestampType(), nullable),
-        #
-        # ID of the child metering point, which is of type 'capacity_settlement'
-        T.StructField(ContractColumnNames.child_metering_point_id, T.StringType(), not nullable),
-        #
-        # The date where the child metering point (of type 'capacity_settlement') was created
-        # UTC time
-        T.StructField(ContractColumnNames.child_period_from_date, T.TimestampType(), not nullable),
-        #
-        # The date where the child metering point (of type 'capacity_settlement') was closed down
-        # UTC time
-        T.StructField(ContractColumnNames.child_period_to_date, T.TimestampType(), nullable),
-    ]
-)
+    schema = T.StructType(
+        [
+            # ID of the consumption metering point (parent)
+            T.StructField(ContractColumnNames.metering_point_id, T.StringType(), not nullable),
+            #
+            # Date when the consumption metering is either (a) entering 'connected'/'disconnected' first time or (b) move-in has occurred.
+            # UTC time
+            T.StructField(ContractColumnNames.period_from_date, T.TimestampType(), not nullable),
+            #
+            # Date when the consumption metering point is closed down or a move-in has occurred.
+            # UTC time
+            T.StructField(ContractColumnNames.period_to_date, T.TimestampType(), nullable),
+            #
+            # ID of the child metering point, which is of type 'capacity_settlement'
+            T.StructField(ContractColumnNames.child_metering_point_id, T.StringType(), not nullable),
+            #
+            # The date where the child metering point (of type 'capacity_settlement') was created
+            # UTC time
+            T.StructField(ContractColumnNames.child_period_from_date, T.TimestampType(), not nullable),
+            #
+            # The date where the child metering point (of type 'capacity_settlement') was closed down
+            # UTC time
+            T.StructField(ContractColumnNames.child_period_to_date, T.TimestampType(), nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/model/ten_largest_quantities.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/model/ten_largest_quantities.py
@@ -11,24 +11,23 @@ class TenLargestQuantities(DataFrameWrapper):
     def __init__(self, df: DataFrame):
         super().__init__(
             df=df,
-            schema=ten_largest_quantities_schema,
+            schema=TenLargestQuantities.schema,
             ignore_nullability=True,
         )
 
-
-ten_largest_quantities_schema = T.StructType(
-    [
-        #
-        # ID of the orchestration that initiated the calculation job
-        T.StructField(ContractColumnNames.orchestration_instance_id, T.StringType(), not nullable),
-        #
-        # Metering point ID
-        T.StructField(ContractColumnNames.metering_point_id, T.StringType(), not nullable),
-        #
-        # UTC time
-        T.StructField(ContractColumnNames.observation_time, T.TimestampType(), not nullable),
-        #
-        # The calculated quantity
-        T.StructField(ContractColumnNames.quantity, T.DecimalType(18, 3), not nullable),
-    ]
-)
+    schema = T.StructType(
+        [
+            #
+            # ID of the orchestration that initiated the calculation job
+            T.StructField(ContractColumnNames.orchestration_instance_id, T.StringType(), not nullable),
+            #
+            # Metering point ID
+            T.StructField(ContractColumnNames.metering_point_id, T.StringType(), not nullable),
+            #
+            # UTC time
+            T.StructField(ContractColumnNames.observation_time, T.TimestampType(), not nullable),
+            #
+            # The calculated quantity
+            T.StructField(ContractColumnNames.quantity, T.DecimalType(18, 3), not nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/model/time_series_points.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/model/time_series_points.py
@@ -13,28 +13,27 @@ class TimeSeriesPoints(DataFrameWrapper):
     def __init__(self, df: DataFrame):
         super().__init__(
             df,
-            time_series_points_v1,
+            TimeSeriesPoints.schema,
             # We ignore_nullability because it has turned out to be too hard and even possibly
             # introducing more errors than solving in order to stay in exact sync with the
             # logically correct schema.
             ignore_nullability=True,
         )
 
-
-time_series_points_v1 = T.StructType(
-    [
-        T.StructField(ContractColumnNames.metering_point_id, T.StringType(), not nullable),
-        #
-        # 'consumption' | 'capacity_settlement'
-        T.StructField(ContractColumnNames.metering_point_type, T.StringType(), not nullable),
-        #
-        # UTC time
-        T.StructField(
-            ContractColumnNames.observation_time,
-            T.TimestampType(),
-            not nullable,
-        ),
-        #
-        T.StructField(ContractColumnNames.quantity, T.DecimalType(18, 3), not nullable),
-    ]
-)
+    schema = T.StructType(
+        [
+            T.StructField(ContractColumnNames.metering_point_id, T.StringType(), not nullable),
+            #
+            # 'consumption' | 'capacity_settlement'
+            T.StructField(ContractColumnNames.metering_point_type, T.StringType(), not nullable),
+            #
+            # UTC time
+            T.StructField(
+                ContractColumnNames.observation_time,
+                T.TimestampType(),
+                not nullable,
+            ),
+            #
+            T.StructField(ContractColumnNames.quantity, T.DecimalType(18, 3), not nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/common/domain/__init__.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/common/domain/__init__.py
@@ -1,13 +1,9 @@
 import geh_calculated_measurements.common.domain.model.calculated_measurements_factory as calculated_measurements_factory
 from geh_calculated_measurements.common.domain.column_names import ContractColumnNames
-from geh_calculated_measurements.common.domain.model.calculated_measurements import (
-    CalculatedMeasurements,
-    calculated_measurements_schema,
-)
+from geh_calculated_measurements.common.domain.model.calculated_measurements import CalculatedMeasurements
 
 __all__ = [
     "CalculatedMeasurements",
-    "calculated_measurements_schema",
     "calculated_measurements_factory",
     "ContractColumnNames",
 ]

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/common/domain/model/calculated_measurements.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/common/domain/model/calculated_measurements.py
@@ -7,48 +7,45 @@ from geh_calculated_measurements.common.domain.column_names import ContractColum
 nullable = True
 
 
-calculated_measurements_schema = T.StructType(
-    [
-        #
-        # "electrical_heating" or "capacity_settlement"
-        T.StructField(ContractColumnNames.orchestration_type, T.StringType(), not nullable),
-        #
-        # ID of the orchestration that initiated the calculation job
-        T.StructField(ContractColumnNames.orchestration_instance_id, T.StringType(), not nullable),
-        #
-        # Transaction ID. Created by the calculation job.
-        # The ID refers to a continous set of measurements for a specific combination of orchestration_id and metering_point_id.
-        # There are no time gaps for a given transaction id. Gaps introduces a new transaction ID after the gap.
-        T.StructField(ContractColumnNames.transaction_id, T.StringType(), not nullable),
-        #
-        # A DateTime value indicating when the transaction was created
-        # by the calculation job.
-        T.StructField(ContractColumnNames.transaction_creation_datetime, T.TimestampType(), not nullable),
-        #
-        # Metering point ID
-        T.StructField(ContractColumnNames.metering_point_id, T.StringType(), not nullable),
-        #
-        # "electrical_heating" | "capacity_settlement" | "net_consumption"
-        T.StructField(ContractColumnNames.metering_point_type, T.StringType(), not nullable),
-        #
-        # UTC time
-        T.StructField(
-            ContractColumnNames.date,
-            T.TimestampType(),
-            not nullable,
-        ),
-        # The calculated quantity
-        T.StructField(ContractColumnNames.quantity, T.DecimalType(18, 3), not nullable),
-    ]
-)
-
-
 class CalculatedMeasurements(DataFrameWrapper):
     def __init__(self, df: DataFrame):
         super().__init__(
             df=df,
-            schema=calculated_measurements_schema,
+            schema=CalculatedMeasurements.schema,
             ignore_nullability=True,
         )
 
-    schema = calculated_measurements_schema
+    schema = T.StructType(
+        [
+            #
+            # "electrical_heating" or "capacity_settlement"
+            T.StructField(ContractColumnNames.orchestration_type, T.StringType(), not nullable),
+            #
+            # ID of the orchestration that initiated the calculation job
+            T.StructField(ContractColumnNames.orchestration_instance_id, T.StringType(), not nullable),
+            #
+            # Transaction ID. Created by the calculation job.
+            # The ID refers to a continous set of measurements for a specific combination of orchestration_id and metering_point_id.
+            # There are no time gaps for a given transaction id. Gaps introduces a new transaction ID after the gap.
+            T.StructField(ContractColumnNames.transaction_id, T.StringType(), not nullable),
+            #
+            # A DateTime value indicating when the transaction was created
+            # by the calculation job.
+            T.StructField(ContractColumnNames.transaction_creation_datetime, T.TimestampType(), not nullable),
+            #
+            # Metering point ID
+            T.StructField(ContractColumnNames.metering_point_id, T.StringType(), not nullable),
+            #
+            # "electrical_heating" | "capacity_settlement" | "net_consumption"
+            T.StructField(ContractColumnNames.metering_point_type, T.StringType(), not nullable),
+            #
+            # UTC time
+            T.StructField(
+                ContractColumnNames.date,
+                T.TimestampType(),
+                not nullable,
+            ),
+            # The calculated quantity
+            T.StructField(ContractColumnNames.quantity, T.DecimalType(18, 3), not nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/__init__.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/__init__.py
@@ -2,7 +2,6 @@ from geh_calculated_measurements.electrical_heating.domain.ephemeral_column_name
 from geh_calculated_measurements.electrical_heating.domain.model.child_metering_points import ChildMeteringPoints
 from geh_calculated_measurements.electrical_heating.domain.model.consumption_metering_point_periods import (
     ConsumptionMeteringPointPeriods,
-    consumption_metering_point_periods_v1,
 )
 from geh_calculated_measurements.electrical_heating.domain.model.time_series_points import (
     TimeSeriesPoints,
@@ -18,5 +17,4 @@ __all__ = [
     "time_series_points_v1",
     "ChildMeteringPoints",
     "ConsumptionMeteringPointPeriods",
-    "consumption_metering_point_periods_v1",
 ]

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/__init__.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/__init__.py
@@ -1,8 +1,5 @@
 from geh_calculated_measurements.electrical_heating.domain.ephemeral_column_names import EphemeralColumnNames
-from geh_calculated_measurements.electrical_heating.domain.model.child_metering_points import (
-    ChildMeteringPoints,
-    child_metering_points_v1,
-)
+from geh_calculated_measurements.electrical_heating.domain.model.child_metering_points import ChildMeteringPoints
 from geh_calculated_measurements.electrical_heating.domain.model.consumption_metering_point_periods import (
     ConsumptionMeteringPointPeriods,
     consumption_metering_point_periods_v1,
@@ -20,7 +17,6 @@ __all__ = [
     "TimeSeriesPoints",
     "time_series_points_v1",
     "ChildMeteringPoints",
-    "child_metering_points_v1",
     "ConsumptionMeteringPointPeriods",
     "consumption_metering_point_periods_v1",
 ]

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/__init__.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/__init__.py
@@ -3,10 +3,7 @@ from geh_calculated_measurements.electrical_heating.domain.model.child_metering_
 from geh_calculated_measurements.electrical_heating.domain.model.consumption_metering_point_periods import (
     ConsumptionMeteringPointPeriods,
 )
-from geh_calculated_measurements.electrical_heating.domain.model.time_series_points import (
-    TimeSeriesPoints,
-    time_series_points_v1,
-)
+from geh_calculated_measurements.electrical_heating.domain.model.time_series_points import TimeSeriesPoints
 
 from .calculation import execute
 
@@ -14,7 +11,6 @@ __all__ = [
     "execute",
     "EphemeralColumnNames",
     "TimeSeriesPoints",
-    "time_series_points_v1",
     "ChildMeteringPoints",
     "ConsumptionMeteringPointPeriods",
 ]

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/model/child_metering_points.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/model/child_metering_points.py
@@ -23,7 +23,7 @@ class ChildMeteringPoints(DataFrameWrapper):
 
     Periods are included when
     - the metering point is of type
-      'supply_to_grid' 'consumption_from_grid' | 'electrical_heating' | 'net_consumption'
+      'supply_to_grid' | 'consumption_from_grid' | 'electrical_heating' | 'net_consumption'
     - the metering point is coupled to a parent metering point
       Note: The same child metering point cannot be re-coupled after being uncoupled
     - the child metering point physical status is connected or disconnected.

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/model/child_metering_points.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/model/child_metering_points.py
@@ -11,51 +11,50 @@ class ChildMeteringPoints(DataFrameWrapper):
     def __init__(self, df: DataFrame) -> None:
         super().__init__(
             df,
-            child_metering_points_v1,
+            ChildMeteringPoints.schema,
             # We ignore_nullability because it has turned out to be too hard and even possibly
             # introducing more errors than solving in order to stay in exact sync with the
             # logically correct schema.
             ignore_nullability=True,
         )
 
+    """
+    Child metering points related to electrical heating.
 
-"""
-Child metering points related to electrical heating.
+    Periods are included when
+    - the metering point is of type
+      'supply_to_grid' 'consumption_from_grid' | 'electrical_heating' | 'net_consumption'
+    - the metering point is coupled to a parent metering point
+      Note: The same child metering point cannot be re-coupled after being uncoupled
+    - the child metering point physical status is connected or disconnected.
+    - the period does not end before 2021-01-01
 
-Periods are included when
-- the metering point is of type
-  'supply_to_grid' 'consumption_from_grid' | 'electrical_heating' | 'net_consumption'
-- the metering point is coupled to a parent metering point
-  Note: The same child metering point cannot be re-coupled after being uncoupled
-- the child metering point physical status is connected or disconnected.
-- the period does not end before 2021-01-01
-
-Formatting is according to ADR-144 with the following constraints:
-- No column may use quoted values
-- All date/time values must include seconds
-"""
-child_metering_points_v1 = t.StructType(
-    [
-        #
-        # GSRN number
-        t.StructField("metering_point_id", t.StringType(), not nullable),
-        #
-        # 'supply_to_grid' | 'consumption_from_grid' |
-        # 'electrical_heating' | 'net_consumption'
-        t.StructField("metering_point_type", t.StringType(), not nullable),
-        #
-        # 'calculated' | 'virtual' | 'physical'
-        t.StructField("metering_point_sub_type", t.StringType(), not nullable),
-        #
-        # GSRN number
-        t.StructField("parent_metering_point_id", t.StringType(), not nullable),
-        #
-        # The date when the child metering point was coupled to the parent metering point
-        # UTC time
-        t.StructField("coupled_date", t.TimestampType(), not nullable),
-        #
-        # The date when the child metering point was uncoupled from the parent metering point
-        # UTC time
-        t.StructField("uncoupled_date", t.TimestampType(), nullable),
-    ]
-)
+    Formatting is according to ADR-144 with the following constraints:
+    - No column may use quoted values
+    - All date/time values must include seconds
+    """
+    schema = t.StructType(
+        [
+            #
+            # GSRN number
+            t.StructField("metering_point_id", t.StringType(), not nullable),
+            #
+            # 'supply_to_grid' | 'consumption_from_grid' |
+            # 'electrical_heating' | 'net_consumption'
+            t.StructField("metering_point_type", t.StringType(), not nullable),
+            #
+            # 'calculated' | 'virtual' | 'physical'
+            t.StructField("metering_point_sub_type", t.StringType(), not nullable),
+            #
+            # GSRN number
+            t.StructField("parent_metering_point_id", t.StringType(), not nullable),
+            #
+            # The date when the child metering point was coupled to the parent metering point
+            # UTC time
+            t.StructField("coupled_date", t.TimestampType(), not nullable),
+            #
+            # The date when the child metering point was uncoupled from the parent metering point
+            # UTC time
+            t.StructField("uncoupled_date", t.TimestampType(), nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/model/consumption_metering_point_periods.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/model/consumption_metering_point_periods.py
@@ -11,75 +11,74 @@ class ConsumptionMeteringPointPeriods(DataFrameWrapper):
     def __init__(self, df: DataFrame) -> None:
         super().__init__(
             df,
-            consumption_metering_point_periods_v1,
+            schema=ConsumptionMeteringPointPeriods.schema,
             # We ignore_nullability because it has turned out to be too hard and even possibly
             # introducing more errors than solving in order to stay in exact sync with the
             # logically correct schema.
             ignore_nullability=True,
         )
 
+    """
+    Consumption (parent) metering points related to electrical heating.
+    The data is periodized; the following transaction types are relevant for determining the periods:
+    - CHANGESUP: Leverandørskift (BRS-001)
+    - ENDSUPPLY: Leveranceophør (BRS-002)
+    - INCCHGSUP: Håndtering af fejlagtigt leverandørskift (BRS-003)
+    - MSTDATSBM: Fremsendelse af stamdata (BRS-006) - Skift af nettoafregningsgrupper
+    - LNKCHLDMP: Tilkobling af D15 til parent i nettoafregningsgruppe 2
+    - ULNKCHLDMP: Afkobling af D15 af parent i nettoafregningsgruppe 2
+    - ULNKCHLDMP: Afkobling af D14 af parent
+    - MOVEINES: Tilflytning - meldt til elleverandøren (BRS-009)
+    - MOVEOUTES: Fraflytning - meldt til elleverandøren (BRS-010)
+    - INCMOVEAUT: Fejlagtig flytning - Automatisk (BRS-011)
+    - INCMOVEMAN: Fejlagtig flytning - Manuel (BRS-011) HTX
+    - MDCNSEHON: Oprettelse af elvarme (BRS-015) Det bliver til BRS-041 i DH3
+    - MDCNSEHOFF: Fjernelse af elvarme (BRS-015) Det bliver til BRS-041 i DH3
+    - CHGSUPSHRT: Leverandørskift med kort varsel (BRS-043). Findes ikke i DH3
+    - MANCHGSUP: Tvunget leverandørskifte på målepunkt (BRS-044).
+    - MANCOR (HTX): Manuelt korrigering
+    Periods are  included when
+    - the metering point physical status is connected or disconnected
+    - the period does not end before 2021-01-01
+    - the electrical heating is or has been registered for the period
 
-"""
-Consumption (parent) metering points related to electrical heating.
-The data is periodized; the following transaction types are relevant for determining the periods:
-- CHANGESUP: Leverandørskift (BRS-001)
-- ENDSUPPLY: Leveranceophør (BRS-002)
-- INCCHGSUP: Håndtering af fejlagtigt leverandørskift (BRS-003)
-- MSTDATSBM: Fremsendelse af stamdata (BRS-006) - Skift af nettoafregningsgrupper
-- LNKCHLDMP: Tilkobling af D15 til parent i nettoafregningsgruppe 2
-- ULNKCHLDMP: Afkobling af D15 af parent i nettoafregningsgruppe 2
-- ULNKCHLDMP: Afkobling af D14 af parent
-- MOVEINES: Tilflytning - meldt til elleverandøren (BRS-009)
-- MOVEOUTES: Fraflytning - meldt til elleverandøren (BRS-010)
-- INCMOVEAUT: Fejlagtig flytning - Automatisk (BRS-011)
-- INCMOVEMAN: Fejlagtig flytning - Manuel (BRS-011) HTX
-- MDCNSEHON: Oprettelse af elvarme (BRS-015) Det bliver til BRS-041 i DH3
-- MDCNSEHOFF: Fjernelse af elvarme (BRS-015) Det bliver til BRS-041 i DH3
-- CHGSUPSHRT: Leverandørskift med kort varsel (BRS-043). Findes ikke i DH3
-- MANCHGSUP: Tvunget leverandørskifte på målepunkt (BRS-044).
-- MANCOR (HTX): Manuelt korrigering
-Periods are  included when
-- the metering point physical status is connected or disconnected
-- the period does not end before 2021-01-01
-- the electrical heating is or has been registered for the period
-
-Formatting is according to ADR-144 with the following constraints:
-- No column may use quoted values
-- All date/time values must include seconds
-"""
-consumption_metering_point_periods_v1 = t.StructType(
-    [
-        #
-        # GSRN number
-        t.StructField("metering_point_id", t.StringType(), not nullable),
-        #
-        # States whether the metering point has electrical heating in the period
-        # true:  The consumption metering has electrical heating in the stated period
-        # false: The consumption metering point was previously marked as having electrical
-        #        heating in the stated period, but this has been corrected
-        # <true | false>
-        t.StructField("has_electrical_heating", t.BooleanType(), not nullable),
-        #
-        # <2 | 3 | 4 | 5 | 6 | 99 | NULL>
-        t.StructField("net_settlement_group", t.IntegerType(), nullable),
-        #
-        # Settlement month is 1st of January for all consumption with electrical heating except for
-        # net settlement group 6, where the date is the scheduled meter reading date.
-        # The number of the month. 1 is January, 12 is December.
-        # For all but settlement group 6 the month is January.
-        # <1 | 2 | 3 | ... | 12>
-        t.StructField(
-            "settlement_month",
-            t.IntegerType(),
-            not nullable,
-        ),
-        #
-        # See the description of periodization of data above.
-        # <UTC time>
-        t.StructField("period_from_date", t.TimestampType(), not nullable),
-        #
-        # See the description of periodization of data above.
-        # <UTC time>
-        t.StructField("period_to_date", t.TimestampType(), nullable),
-    ]
-)
+    Formatting is according to ADR-144 with the following constraints:
+    - No column may use quoted values
+    - All date/time values must include seconds
+    """
+    schema = t.StructType(
+        [
+            #
+            # GSRN number
+            t.StructField("metering_point_id", t.StringType(), not nullable),
+            #
+            # States whether the metering point has electrical heating in the period
+            # true:  The consumption metering has electrical heating in the stated period
+            # false: The consumption metering point was previously marked as having electrical
+            #        heating in the stated period, but this has been corrected
+            # <true | false>
+            t.StructField("has_electrical_heating", t.BooleanType(), not nullable),
+            #
+            # <2 | 3 | 4 | 5 | 6 | 99 | NULL>
+            t.StructField("net_settlement_group", t.IntegerType(), nullable),
+            #
+            # Settlement month is 1st of January for all consumption with electrical heating except for
+            # net settlement group 6, where the date is the scheduled meter reading date.
+            # The number of the month. 1 is January, 12 is December.
+            # For all but settlement group 6 the month is January.
+            # <1 | 2 | 3 | ... | 12>
+            t.StructField(
+                "settlement_month",
+                t.IntegerType(),
+                not nullable,
+            ),
+            #
+            # See the description of periodization of data above.
+            # <UTC time>
+            t.StructField("period_from_date", t.TimestampType(), not nullable),
+            #
+            # See the description of periodization of data above.
+            # <UTC time>
+            t.StructField("period_to_date", t.TimestampType(), nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/model/time_series_points.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/domain/model/time_series_points.py
@@ -11,37 +11,36 @@ class TimeSeriesPoints(DataFrameWrapper):
     def __init__(self, df: DataFrame) -> None:
         super().__init__(
             df,
-            time_series_points_v1,
+            schema=TimeSeriesPoints.schema,
             # We ignore_nullability because it has turned out to be too hard and even possibly
             # introducing more errors than solving in order to stay in exact sync with the
             # logically correct schema.
             ignore_nullability=True,
         )
 
-
-# Time series points related to electrical heating.
-#
-# Points are included when:
-# - the unit is kWh
-# - the metering point type is one of those listed below
-# - the observation time is after 2021-01-01
-time_series_points_v1 = t.StructType(
-    [
-        #
-        # GSRN number
-        t.StructField("metering_point_id", t.StringType(), not nullable),
-        #
-        # 'consumption' | 'supply_to_grid' | 'consumption_from_grid' |
-        # 'electrical_heating' | 'net_consumption'
-        t.StructField("metering_point_type", t.StringType(), not nullable),
-        #
-        # UTC time
-        t.StructField(
-            "observation_time",
-            t.TimestampType(),
-            not nullable,
-        ),
-        #
-        t.StructField("quantity", t.DecimalType(18, 3), not nullable),
-    ]
-)
+    # Time series points related to electrical heating.
+    #
+    # Points are included when:
+    # - the unit is kWh
+    # - the metering point type is one of those listed below
+    # - the observation time is after 2021-01-01
+    schema = t.StructType(
+        [
+            #
+            # GSRN number
+            t.StructField("metering_point_id", t.StringType(), not nullable),
+            #
+            # 'consumption' | 'supply_to_grid' | 'consumption_from_grid' |
+            # 'electrical_heating' | 'net_consumption'
+            t.StructField("metering_point_type", t.StringType(), not nullable),
+            #
+            # UTC time
+            t.StructField(
+                "observation_time",
+                t.TimestampType(),
+                not nullable,
+            ),
+            #
+            t.StructField("quantity", t.DecimalType(18, 3), not nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/infrastructure/electricity_market/repository.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/infrastructure/electricity_market/repository.py
@@ -4,7 +4,6 @@ from pyspark.sql import SparkSession
 from geh_calculated_measurements.electrical_heating.domain import (
     ChildMeteringPoints,
     ConsumptionMeteringPointPeriods,
-    child_metering_points_v1,
     consumption_metering_point_periods_v1,
 )
 
@@ -29,5 +28,5 @@ class Repository:
 
     def read_child_metering_points(self) -> ChildMeteringPoints:
         file_path = f"{self._electricity_market_data_path}/{self._child_metering_points_file_name}"
-        df = read_csv_path(spark=self._spark, path=file_path, schema=child_metering_points_v1)
+        df = read_csv_path(spark=self._spark, path=file_path, schema=ChildMeteringPoints.schema)
         return ChildMeteringPoints(df)

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/infrastructure/electricity_market/repository.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/infrastructure/electricity_market/repository.py
@@ -4,7 +4,6 @@ from pyspark.sql import SparkSession
 from geh_calculated_measurements.electrical_heating.domain import (
     ChildMeteringPoints,
     ConsumptionMeteringPointPeriods,
-    consumption_metering_point_periods_v1,
 )
 
 
@@ -23,7 +22,7 @@ class Repository:
 
     def read_consumption_metering_point_periods(self) -> ConsumptionMeteringPointPeriods:
         file_path = f"{self._electricity_market_data_path}/{self._consumption_metering_point_periods_file_name}"
-        df = read_csv_path(spark=self._spark, path=file_path, schema=consumption_metering_point_periods_v1)
+        df = read_csv_path(spark=self._spark, path=file_path, schema=ConsumptionMeteringPointPeriods.schema)
         return ConsumptionMeteringPointPeriods(df)
 
     def read_child_metering_points(self) -> ChildMeteringPoints:

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/infrastructure/measurements_gold/database_definitions.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/electrical_heating/infrastructure/measurements_gold/database_definitions.py
@@ -1,9 +1,3 @@
-from geh_calculated_measurements.electrical_heating.domain import time_series_points_v1
-
-
 class MeasurementsGoldDatabaseDefinition:
     DATABASE_NAME = "measurements_gold"
     TIME_SERIES_POINTS_NAME = "electrical_heating_v1"
-
-
-electrical_heating_v1_schema = time_series_points_v1

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/net_consumption_group_6/domain/cenc.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/net_consumption_group_6/domain/cenc.py
@@ -1,11 +1,8 @@
 from datetime import datetime
 from decimal import Decimal
 
-import pyspark.sql.types as T
-from geh_common.pyspark.data_frame_wrapper import DataFrameWrapper
 from geh_common.telemetry import use_span
 from geh_common.testing.dataframes import testing
-from pyspark.sql import DataFrame
 
 from geh_calculated_measurements.common.infrastructure import initialize_spark
 from geh_calculated_measurements.net_consumption_group_6.domain.model import (
@@ -13,21 +10,6 @@ from geh_calculated_measurements.net_consumption_group_6.domain.model import (
     ConsumptionMeteringPointPeriods,
     TimeSeriesPoints,
 )
-
-_cenc_schema = T.StructType(
-    [
-        T.StructField("orchestration_instance_id", T.StringType(), False),
-        T.StructField("metering_point_id", T.StringType(), False),
-        T.StructField("quantity", T.DecimalType(18, 3), False),
-        T.StructField("settlement_year", T.IntegerType(), False),
-        T.StructField("settlement_month", T.IntegerType(), False),
-    ]
-)
-
-
-class Cenc(DataFrameWrapper):
-    def __init__(self, df: DataFrame):
-        super().__init__(df=df, schema=_cenc_schema, ignore_nullability=True)
 
 
 @use_span()
@@ -45,6 +27,6 @@ def calculate_cenc(
     spark = initialize_spark()
     # TODO JVM: Hardcoded data to match the first scenario test
     data = [("00000000-0000-0000-0000-000000000001", "150000001500170200", Decimal("1000.000"), 2025, 1)]
-    df = spark.createDataFrame(data, schema=_cenc_schema)
+    df = spark.createDataFrame(data, schema=Cenc.schema)
 
     return Cenc(df)

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/net_consumption_group_6/domain/model/cenc.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/net_consumption_group_6/domain/model/cenc.py
@@ -2,19 +2,17 @@ import pyspark.sql.types as T
 from geh_common.pyspark.data_frame_wrapper import DataFrameWrapper
 from pyspark.sql import DataFrame
 
-_cenc_schema = T.StructType(
-    [
-        T.StructField("orchestration_instance_id", T.StringType(), False),
-        T.StructField("metering_point_id", T.StringType(), False),
-        T.StructField("quantity", T.DecimalType(18, 3), False),
-        T.StructField("settlement_year", T.IntegerType(), False),
-        T.StructField("settlement_month", T.IntegerType(), False),
-    ]
-)
-
 
 class Cenc(DataFrameWrapper):
     def __init__(self, df: DataFrame):
-        super().__init__(df=df, schema=_cenc_schema, ignore_nullability=True)
+        super().__init__(df=df, schema=Cenc.schema, ignore_nullability=True)
 
-    schema = _cenc_schema
+    schema = T.StructType(
+        [
+            T.StructField("orchestration_instance_id", T.StringType(), False),
+            T.StructField("metering_point_id", T.StringType(), False),
+            T.StructField("quantity", T.DecimalType(18, 3), False),
+            T.StructField("settlement_year", T.IntegerType(), False),
+            T.StructField("settlement_month", T.IntegerType(), False),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/net_consumption_group_6/domain/model/child_metering_points.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/net_consumption_group_6/domain/model/child_metering_points.py
@@ -4,43 +4,6 @@ from pyspark.sql import DataFrame
 
 nullable = True
 
-"""
-Child metering points related to electrical heating.
-
-Periods are included when
-- the metering point is of type
-  'supply_to_grid' | 'consumption_from_grid' | 'net_consumption'
-- the metering point is coupled to a parent metering point
-  Note: The same child metering point cannot be re-coupled after being uncoupled
-- the child metering point physical status is connected or disconnected.
-- the period does not end before 2021-01-01
-
-CSV formatting is according to ADR-144 with the following constraints:
-- No column may use quoted values
-- All date/time values must include seconds
-"""
-_child_metering_points_v1 = t.StructType(
-    [
-        #
-        # GSRN number
-        t.StructField("metering_point_id", t.StringType(), not nullable),
-        #
-        # 'supply_to_grid' | 'consumption_from_grid' | 'net_consumption'
-        t.StructField("metering_point_type", t.StringType(), not nullable),
-        #
-        # GSRN number
-        t.StructField("parent_metering_point_id", t.StringType(), not nullable),
-        #
-        # The date when the child metering point was coupled to the parent metering point
-        # UTC time
-        t.StructField("coupled_date", t.TimestampType(), not nullable),
-        #
-        # The date when the child metering point was uncoupled from the parent metering point
-        # UTC time
-        t.StructField("uncoupled_date", t.TimestampType(), nullable),
-    ]
-)
-
 
 class ChildMeteringPoints(DataFrameWrapper):
     """Represents the child metering points data structure."""
@@ -48,11 +11,46 @@ class ChildMeteringPoints(DataFrameWrapper):
     def __init__(self, df: DataFrame) -> None:
         super().__init__(
             df,
-            _child_metering_points_v1,
+            schema=ChildMeteringPoints.schema,
             # We ignore_nullability because it has turned out to be too hard and even possibly
             # introducing more errors than solving in order to stay in exact sync with the
             # logically correct schema.
             ignore_nullability=True,
         )
 
-    schema = _child_metering_points_v1
+    """
+    Child metering points related to electrical heating.
+
+    Periods are included when
+    - the metering point is of type
+    'supply_to_grid' | 'consumption_from_grid' | 'net_consumption'
+    - the metering point is coupled to a parent metering point
+    Note: The same child metering point cannot be re-coupled after being uncoupled
+    - the child metering point physical status is connected or disconnected.
+    - the period does not end before 2021-01-01
+
+    CSV formatting is according to ADR-144 with the following constraints:
+    - No column may use quoted values
+    - All date/time values must include seconds
+    """
+    schema = t.StructType(
+        [
+            #
+            # GSRN number
+            t.StructField("metering_point_id", t.StringType(), not nullable),
+            #
+            # 'supply_to_grid' | 'consumption_from_grid' | 'net_consumption'
+            t.StructField("metering_point_type", t.StringType(), not nullable),
+            #
+            # GSRN number
+            t.StructField("parent_metering_point_id", t.StringType(), not nullable),
+            #
+            # The date when the child metering point was coupled to the parent metering point
+            # UTC time
+            t.StructField("coupled_date", t.TimestampType(), not nullable),
+            #
+            # The date when the child metering point was uncoupled from the parent metering point
+            # UTC time
+            t.StructField("uncoupled_date", t.TimestampType(), nullable),
+        ]
+    )

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/net_consumption_group_6/domain/model/time_series_points.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/net_consumption_group_6/domain/model/time_series_points.py
@@ -5,44 +5,40 @@ from pyspark.sql import DataFrame
 nullable = True
 
 
-# Time series points related to electrical heating.
-#
-# Points are included when:
-# - the unit is kWh
-# - the metering point type is one of those listed below
-# - the observation time is after 2021-01-01
-_time_series_points_v1 = t.StructType(
-    [
-        #
-        # GSRN number
-        t.StructField("metering_point_id", t.StringType(), not nullable),
-        #
-        # 'consumption' | 'supply_to_grid' | 'consumption_from_grid' | 'net_consumption'
-        t.StructField("metering_point_type", t.StringType(), not nullable),
-        #
-        # UTC time
-        t.StructField(
-            "observation_time",
-            t.TimestampType(),
-            not nullable,
-        ),
-        #
-        t.StructField("quantity", t.DecimalType(18, 3), not nullable),
-    ]
-)
-
-
 class TimeSeriesPoints(DataFrameWrapper):
     """Represents the time series points data structure."""
 
     def __init__(self, df: DataFrame) -> None:
         super().__init__(
             df,
-            _time_series_points_v1,
+            schema=TimeSeriesPoints.schema,
             # We ignore_nullability because it has turned out to be too hard and even possibly
             # introducing more errors than solving in order to stay in exact sync with the
             # logically correct schema.
             ignore_nullability=True,
         )
 
-    schema = _time_series_points_v1
+    schema = t.StructType(
+        [
+            #
+            # GSRN number
+            t.StructField("metering_point_id", t.StringType(), not nullable),
+            #
+            # 'consumption' | 'supply_to_grid' | 'consumption_from_grid' | 'net_consumption'
+            t.StructField("metering_point_type", t.StringType(), not nullable),
+            #
+            # UTC time
+            t.StructField(
+                "observation_time",
+                t.TimestampType(),
+                not nullable,
+            ),
+            #
+            t.StructField("quantity", t.DecimalType(18, 3), not nullable),
+        ]
+    )
+    """Time series points related to electrical heating.
+    Points are included when:
+    - the unit is kWh
+    - the metering point type is one of those listed below
+    - the observation time is after 2021-01-01"""

--- a/source/geh_calculated_measurements/tests/capacity_settlement/job_tests/conftest.py
+++ b/source/geh_calculated_measurements/tests/capacity_settlement/job_tests/conftest.py
@@ -9,7 +9,7 @@ from geh_calculated_measurements.capacity_settlement.infrastructure import (
 from geh_calculated_measurements.capacity_settlement.infrastructure.measurements_gold.schema import (
     capacity_settlement_v1,
 )
-from geh_calculated_measurements.common.domain import calculated_measurements_schema
+from geh_calculated_measurements.common.domain import CalculatedMeasurements
 from geh_calculated_measurements.common.infrastructure import CalculatedMeasurementsInternalDatabaseDefinition
 from tests.capacity_settlement.job_tests import TEST_FILES_FOLDER_PATH
 
@@ -43,6 +43,6 @@ def calculated_measurements_table_created(spark: SparkSession) -> None:
         spark,
         database_name=CalculatedMeasurementsInternalDatabaseDefinition.DATABASE_NAME,
         table_name=CalculatedMeasurementsInternalDatabaseDefinition.MEASUREMENTS_TABLE_NAME,
-        schema=calculated_measurements_schema,
+        schema=CalculatedMeasurements.schema,
         table_location=f"{CalculatedMeasurementsInternalDatabaseDefinition.DATABASE_NAME}/{CalculatedMeasurementsInternalDatabaseDefinition.MEASUREMENTS_TABLE_NAME}",
     )

--- a/source/geh_calculated_measurements/tests/data_products/conftest.py
+++ b/source/geh_calculated_measurements/tests/data_products/conftest.py
@@ -6,7 +6,7 @@ from geh_common.testing.dataframes import write_when_files_to_delta
 from geh_common.testing.scenario_testing import TestCase, TestCases, get_then_names
 from pyspark.sql import SparkSession
 
-from geh_calculated_measurements.common.domain.model import calculated_measurements
+from geh_calculated_measurements.common.domain import CalculatedMeasurements
 from geh_calculated_measurements.common.infrastructure import CalculatedMeasurementsDatabaseDefinition
 from geh_calculated_measurements.database_migrations.settings.catalog_settings import CatalogSettings
 
@@ -27,7 +27,7 @@ def test_cases(spark: SparkSession, request: pytest.FixtureRequest) -> TestCases
     path_schema_tuples = [
         (
             "measurements_calculated_internal.calculated_measurements.csv",
-            calculated_measurements.calculated_measurements_schema,
+            CalculatedMeasurements.schema,
         )
     ]
     write_when_files_to_delta(

--- a/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/infrastructure/test_column_names.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/infrastructure/test_column_names.py
@@ -5,7 +5,7 @@ from geh_calculated_measurements.electrical_heating.domain import (
     ChildMeteringPoints,
     ConsumptionMeteringPointPeriods,
     EphemeralColumnNames,
-    time_series_points_v1,
+    TimeSeriesPoints,
 )
 
 # Imports for all other StructTypes in the infrastructure directory
@@ -13,7 +13,7 @@ ALL_CONTRACT_STRUCT_TYPES = [
     ChildMeteringPoints.schema,
     ConsumptionMeteringPointPeriods.schema,
     CalculatedMeasurements.schema,
-    time_series_points_v1,
+    TimeSeriesPoints.schema,
 ]
 
 

--- a/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/infrastructure/test_column_names.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/infrastructure/test_column_names.py
@@ -3,15 +3,15 @@ import pytest
 from geh_calculated_measurements.common.domain import CalculatedMeasurements, ContractColumnNames
 from geh_calculated_measurements.electrical_heating.domain import (
     ChildMeteringPoints,
+    ConsumptionMeteringPointPeriods,
     EphemeralColumnNames,
-    consumption_metering_point_periods_v1,
     time_series_points_v1,
 )
 
 # Imports for all other StructTypes in the infrastructure directory
 ALL_CONTRACT_STRUCT_TYPES = [
     ChildMeteringPoints.schema,
-    consumption_metering_point_periods_v1,
+    ConsumptionMeteringPointPeriods.schema,
     CalculatedMeasurements.schema,
     time_series_points_v1,
 ]

--- a/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/infrastructure/test_column_names.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/infrastructure/test_column_names.py
@@ -2,15 +2,15 @@ import pytest
 
 from geh_calculated_measurements.common.domain import CalculatedMeasurements, ContractColumnNames
 from geh_calculated_measurements.electrical_heating.domain import (
+    ChildMeteringPoints,
     EphemeralColumnNames,
-    child_metering_points_v1,
     consumption_metering_point_periods_v1,
     time_series_points_v1,
 )
 
 # Imports for all other StructTypes in the infrastructure directory
 ALL_CONTRACT_STRUCT_TYPES = [
-    child_metering_points_v1,
+    ChildMeteringPoints.schema,
     consumption_metering_point_periods_v1,
     CalculatedMeasurements.schema,
     time_series_points_v1,

--- a/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/infrastructure/test_column_names.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/electrical_heating_tests/infrastructure/test_column_names.py
@@ -1,6 +1,6 @@
 import pytest
 
-from geh_calculated_measurements.common.domain import ContractColumnNames, calculated_measurements_schema
+from geh_calculated_measurements.common.domain import CalculatedMeasurements, ContractColumnNames
 from geh_calculated_measurements.electrical_heating.domain import (
     EphemeralColumnNames,
     child_metering_points_v1,
@@ -12,7 +12,7 @@ from geh_calculated_measurements.electrical_heating.domain import (
 ALL_CONTRACT_STRUCT_TYPES = [
     child_metering_points_v1,
     consumption_metering_point_periods_v1,
-    calculated_measurements_schema,
+    CalculatedMeasurements.schema,
     time_series_points_v1,
 ]
 

--- a/source/geh_calculated_measurements/tests/electrical_heating/job_tests/conftest.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/job_tests/conftest.py
@@ -3,7 +3,7 @@ from geh_common.pyspark.read_csv import read_csv_path
 from geh_common.testing.delta_lake.delta_lake_operations import create_database, create_table
 from pyspark.sql import SparkSession
 
-from geh_calculated_measurements.common.domain import calculated_measurements_schema
+from geh_calculated_measurements.common.domain import CalculatedMeasurements
 from geh_calculated_measurements.common.infrastructure import CalculatedMeasurementsInternalDatabaseDefinition
 from geh_calculated_measurements.electrical_heating.infrastructure import (
     MeasurementsGoldDatabaseDefinition,
@@ -41,6 +41,6 @@ def calculated_measurements_table_created(spark: SparkSession) -> None:
         spark,
         database_name=CalculatedMeasurementsInternalDatabaseDefinition.DATABASE_NAME,
         table_name=CalculatedMeasurementsInternalDatabaseDefinition.MEASUREMENTS_TABLE_NAME,
-        schema=calculated_measurements_schema,
+        schema=CalculatedMeasurements.schema,
         table_location=f"{CalculatedMeasurementsInternalDatabaseDefinition.DATABASE_NAME}/{CalculatedMeasurementsInternalDatabaseDefinition.MEASUREMENTS_TABLE_NAME}",
     )

--- a/source/geh_calculated_measurements/tests/electrical_heating/scenario_tests/conftest.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/scenario_tests/conftest.py
@@ -16,7 +16,6 @@ from geh_calculated_measurements.electrical_heating.domain import (
     ConsumptionMeteringPointPeriods,
     TimeSeriesPoints,
     execute,
-    time_series_points_v1,
 )
 
 _JOB_ENVIRONMENT_VARIABLES = {
@@ -37,7 +36,7 @@ def test_cases(spark: SparkSession, request: pytest.FixtureRequest) -> TestCases
     time_series_points = read_csv(
         spark,
         f"{scenario_path}/when/measurements_gold/time_series_points_v1.csv",
-        time_series_points_v1,
+        TimeSeriesPoints.schema,
     )
     consumption_metering_point_periods = read_csv(
         spark,

--- a/source/geh_calculated_measurements/tests/electrical_heating/scenario_tests/conftest.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/scenario_tests/conftest.py
@@ -15,7 +15,6 @@ from geh_calculated_measurements.electrical_heating.domain import (
     ChildMeteringPoints,
     ConsumptionMeteringPointPeriods,
     TimeSeriesPoints,
-    child_metering_points_v1,
     consumption_metering_point_periods_v1,
     execute,
     time_series_points_v1,
@@ -49,7 +48,7 @@ def test_cases(spark: SparkSession, request: pytest.FixtureRequest) -> TestCases
     child_metering_point_periods = read_csv(
         spark,
         f"{scenario_path}/when/electricity_market__electrical_heating/child_metering_points_v1.csv",
-        child_metering_points_v1,
+        ChildMeteringPoints.schema,
     )
 
     with patch.dict("os.environ", _JOB_ENVIRONMENT_VARIABLES):

--- a/source/geh_calculated_measurements/tests/electrical_heating/scenario_tests/conftest.py
+++ b/source/geh_calculated_measurements/tests/electrical_heating/scenario_tests/conftest.py
@@ -15,7 +15,6 @@ from geh_calculated_measurements.electrical_heating.domain import (
     ChildMeteringPoints,
     ConsumptionMeteringPointPeriods,
     TimeSeriesPoints,
-    consumption_metering_point_periods_v1,
     execute,
     time_series_points_v1,
 )
@@ -43,7 +42,7 @@ def test_cases(spark: SparkSession, request: pytest.FixtureRequest) -> TestCases
     consumption_metering_point_periods = read_csv(
         spark,
         f"{scenario_path}/when/electricity_market__electrical_heating/consumption_metering_point_periods_v1.csv",
-        consumption_metering_point_periods_v1,
+        ConsumptionMeteringPointPeriods.schema,
     )
     child_metering_point_periods = read_csv(
         spark,


### PR DESCRIPTION
Streamline the import statements and update the usage of measurement schemas across various modules to enhance code clarity and maintainability. Remove deprecated references and ensure consistency in schema access.