### PR TITLE
Update geh_common dependency to version 5.4.5

### DIFF
--- a/source/geh_calculated_measurements/pyproject.toml
+++ b/source/geh_calculated_measurements/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "azure-monitor-opentelemetry==1.6.4",
     "configargparse==1.7.0",
     "delta-spark==3.2.0",
-    "geh_common @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@geh_common_5.4.4#subdirectory=source/geh_common",
+    "geh_common @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@geh_common_5.4.5#subdirectory=source/geh_common",
     "pydantic-settings>=2.7.1",
     "pyspark==3.5.1",
     "python-dateutil==2.8.2",

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/calculation.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/capacity_settlement/domain/calculation.py
@@ -24,8 +24,10 @@ from geh_calculated_measurements.common.domain import (
 from geh_calculated_measurements.common.infrastructure import initialize_spark
 
 
-# This is also the function that will be tested using the `testcommon.etl` framework.
 @use_span()
+@testing(selector=lambda x: x.calculations)
+@testing(selector=lambda x: x.calculated_measurements)
+@testing(selector=lambda x: x.ten_largest_quantities)
 def execute(
     time_series_points: TimeSeriesPoints,
     metering_point_periods: MeteringPointPeriods,

--- a/source/geh_calculated_measurements/uv.lock
+++ b/source/geh_calculated_measurements/uv.lock
@@ -454,7 +454,7 @@ requires-dist = [
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.4" },
     { name = "configargparse", specifier = "==1.7.0" },
     { name = "delta-spark", specifier = "==3.2.0" },
-    { name = "geh-common", git = "https://github.com/Energinet-DataHub/opengeh-python-packages?subdirectory=source%2Fgeh_common&rev=geh_common_5.4.3" },
+    { name = "geh-common", git = "https://github.com/Energinet-DataHub/opengeh-python-packages?subdirectory=source%2Fgeh_common&rev=geh_common_5.4.5" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "pyspark", specifier = "==3.5.1" },
     { name = "python-dateutil", specifier = "==2.8.2" },
@@ -473,8 +473,8 @@ dev = [
 
 [[package]]
 name = "geh-common"
-version = "5.4.3"
-source = { git = "https://github.com/Energinet-DataHub/opengeh-python-packages?subdirectory=source%2Fgeh_common&rev=geh_common_5.4.3#403cdf15606ac77d301211c1681ceffedc27fde3" }
+version = "5.4.5"
+source = { git = "https://github.com/Energinet-DataHub/opengeh-python-packages?subdirectory=source%2Fgeh_common&rev=geh_common_5.4.5#9cde44eab1d7b4a8e15eb64a95303c97ea0f0a35" }
 dependencies = [
     { name = "azure-core" },
     { name = "azure-identity" },


### PR DESCRIPTION
Upgrade the geh_common package to the latest version to ensure compatibility and access to recent features and fixes.