### PR TITLE
fix: Use is_cancelled in dotnet measurements API

### DIFF
--- a/source/dotnet/Measurements.Infrastructure/Persistence/MeasurementsGoldConstants.cs
+++ b/source/dotnet/Measurements.Infrastructure/Persistence/MeasurementsGoldConstants.cs
@@ -9,4 +9,5 @@ public static class MeasurementsGoldConstants
     public const string QuantityColumnName = "quantity";
     public const string QualityColumnName = "quality";
     public const string TransactionCreationDatetimeColumnName = "transaction_creation_datetime";
+    public const string IsCancelledColumnName = "is_cancelled";
 }

--- a/source/dotnet/Measurements.Infrastructure/Persistence/Queries/GetMeasurementsQuery.cs
+++ b/source/dotnet/Measurements.Infrastructure/Persistence/Queries/GetMeasurementsQuery.cs
@@ -29,6 +29,7 @@ public class GetMeasurementsQuery : DatabricksStatement
             $"where {MeasurementsGoldConstants.MeteringPointIdColumnName} = '{_meteringPointId}' " +
             $"and {MeasurementsGoldConstants.ObservationTimeColumnName} >= '{_startDate}' " +
             $"and {MeasurementsGoldConstants.ObservationTimeColumnName} < '{_endDate}' " +
+            $"and {MeasurementsGoldConstants.IsCancelledColumnName} is false " +
             $") " +
             $"select {MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.UnitColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName}, {MeasurementsGoldConstants.QuantityColumnName}, {MeasurementsGoldConstants.QualityColumnName} " +
             $"from most_recent " +


### PR DESCRIPTION
# Description

Uses the is_cancelled column added in gold measurements in our measurements API
(written by Henrik, technically 👯‍♂️ )

## References

Separated out from this PR:
https://github.com/Energinet-DataHub/opengeh-measurements/pull/453 
