### PR TITLE
Enable test for writing output in net consumption group 6

### DIFF
--- a/source/geh_calculated_measurements/tests/subsystem_tests/net_consumption_group_6/test_jobs.py
+++ b/source/geh_calculated_measurements/tests/subsystem_tests/net_consumption_group_6/test_jobs.py
@@ -28,9 +28,3 @@ class TestNetConsumptionGroup6(BaseJobTests):
     @pytest.mark.skip(reason="Skipped due to issues with the telemetry data not available in the logs.")
     def test__and_then_job_telemetry_is_created(self, job_fixture: BaseJobFixture) -> None:
         pass
-
-    @pytest.mark.skip(reason="This test is temporary skipped because the storing implementation is not yet made.")
-    def test__and_then_data_is_written_to_delta(
-        self, environment_configuration: EnvironmentConfiguration, job_fixture: BaseJobFixture
-    ) -> None:
-        pass


### PR DESCRIPTION
Activate the test for writing data to delta, which was previously skipped due to incomplete implementation.

The change is tested on dev_002 [here](https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14055271262/job/39353383785). This is extracted from the test output:
`tests/subsystem_tests/net_consumption_group_6/test_jobs.py::TestNetConsumptionGroup6::test__and_then_data_is_written_to_delta <- tests/subsystem_tests/base_resources/base_job_tests.py PASSED`

The subsystem tests, however, failed. But that was for other reasons that I anticipate to be period as they should not be related to this change.