### PR TITLE
fix: Deploy both databricks when changes are made

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
   cd_reusable:
     name: Continuous Deployment
     needs: [changes]
-    if: ${{ needs.changes.outputs.dotnet != 'true' }}
+    if: ${{ needs.changes.outputs.python_packages == 'true' }}
     uses: Energinet-DataHub/.github/.github/workflows/python-uv-cd.yml@v14
     with:
       packages_directory: source

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,8 +26,6 @@ jobs:
 
   cd_reusable:
     name: Continuous Deployment
-    needs: [changes]
-    if: ${{ needs.changes.outputs.python_packages == 'true' }}
     uses: Energinet-DataHub/.github/.github/workflows/python-uv-cd.yml@v14
     with:
       packages_directory: source

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -11,6 +11,8 @@ on:
         value: ${{ jobs.changes.outputs.dotnet }}
       packages:
         value: ${{ jobs.changes.outputs.packages }}
+      python_packages:
+        value: ${{ jobs.changes.outputs.python-packages }}
 
 jobs:
   changes:
@@ -19,6 +21,7 @@ jobs:
     outputs:
       dotnet: ${{ steps.filter.outputs.dotnet }}
       nuget-packages: ${{ steps.filter.outputs.nuget-packages }}
+      python-packages: ${{ steps.filter.outputs.python-packages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,3 +42,6 @@ jobs:
               - 'source/dotnet/Measurements.Client*/**'
               - 'source/dotnet/Measurements.Abstractions*/**'
               - '.github/workflows/measurements-client-bundle-publish.yml'
+            python-packages:
+              - 'source/core/**'
+              - 'source/geh_calculated_measurements/**'

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -11,8 +11,6 @@ on:
         value: ${{ jobs.changes.outputs.dotnet }}
       packages:
         value: ${{ jobs.changes.outputs.packages }}
-      python_packages:
-        value: ${{ jobs.changes.outputs.python-packages }}
 
 jobs:
   changes:
@@ -21,7 +19,6 @@ jobs:
     outputs:
       dotnet: ${{ steps.filter.outputs.dotnet }}
       nuget-packages: ${{ steps.filter.outputs.nuget-packages }}
-      python-packages: ${{ steps.filter.outputs.python-packages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,6 +39,3 @@ jobs:
               - 'source/dotnet/Measurements.Client*/**'
               - 'source/dotnet/Measurements.Abstractions*/**'
               - '.github/workflows/measurements-client-bundle-publish.yml'
-            python-packages:
-              - 'source/core/**'
-              - 'source/geh_calculated_measurements/**'


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->
When there was made changes in both python and dotnet, then only dotnet was deployed. We would like both to be deployed.
