### PR TITLE
fix: Use correct input table name in missing measurements log

### DIFF
--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/missing_measurements_log/infrastructure/database_definitions.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/missing_measurements_log/infrastructure/database_definitions.py
@@ -1,3 +1,3 @@
 class MeteringPointPeriodsDatabaseDefinition:
     DATABASE_NAME = "electricity_market_measurements_input"
-    METERING_POINT_PERIODS = "metering_point_periods_v1"
+    METERING_POINT_PERIODS = "missing_measurements_log_metering_point_periods_v1"


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
