### PR TITLE
chore: Set `skipChangeCommit` when reading from silver

### DIFF
--- a/source/core/src/core/silver/infrastructure/repositories/silver_measurements_repository.py
+++ b/source/core/src/core/silver/infrastructure/repositories/silver_measurements_repository.py
@@ -22,7 +22,12 @@ class SilverMeasurementsRepository:
 
     def read_stream(self) -> DataFrame:
         spark = spark_session.initialize_spark()
-        return spark.readStream.format("delta").option("ignoreDeletes", "true").table(self.table)
+        return (
+            spark.readStream.format("delta")
+            .option("ignoreDeletes", "true")
+            .option("skipChangeCommit", "true")
+            .table(self.table)
+        )
 
     def write_stream(
         self,

--- a/source/core/src/core/silver/infrastructure/repositories/submitted_transactions_repository.py
+++ b/source/core/src/core/silver/infrastructure/repositories/submitted_transactions_repository.py
@@ -15,6 +15,7 @@ class SubmittedTransactionsRepository:
         return (
             self.spark.readStream.format("delta")
             .option("ignoreDeletes", "true")
+            .option("skipChangeCommit", "true")
             .table(f"{self.silver_database_name}.{SilverTableNames.silver_measurements}")
             .filter(
                 f"{SilverMeasurementsColumnNames.orchestration_type} = '{GehCommonOrchestrationType.SUBMITTED.value}'"

--- a/source/core/tests/silver/infrastructure/repositories/test_submitted_transactions_repository.py
+++ b/source/core/tests/silver/infrastructure/repositories/test_submitted_transactions_repository.py
@@ -24,8 +24,9 @@ def test__read_submitted_transactions__calls_expected() -> None:
     # Assert
     mock_spark.readStream.format.assert_called_once_with("delta")
     mock_spark.readStream.format().option.assert_called_once_with("ignoreDeletes", "true")
-    mock_spark.readStream.format().option().table.assert_called_once_with(expected_table)
-    mock_spark.readStream.format().option().table().filter.assert_called_once_with(
+    mock_spark.readStream.format().option().option.assert_called_once_with("skipChangeCommit", "true")
+    mock_spark.readStream.format().option().option().table.assert_called_once_with(expected_table)
+    mock_spark.readStream.format().option().option().table().filter.assert_called_once_with(
         f"{SilverMeasurementsColumnNames.orchestration_type} = '{GehCommonOrchestrationType.SUBMITTED.value}'"
     )
 


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->
As we have made changes to our data the stream readings from silver are failing. This is because it does not expect changes to be made. 

When adding `skipChangeCommit` it will ignore those changes.
