### PR TITLE
Use correct term "CENC" in measurement files

### DIFF
--- a/source/geh_calculated_measurements/tests/net_consumption_group_6/scenario_tests/nsg6_up_to_end_change_to_summer_time/then/measurements.csv
+++ b/source/geh_calculated_measurements/tests/net_consumption_group_6/scenario_tests/nsg6_up_to_end_change_to_summer_time/then/measurements.csv
@@ -1,5 +1,5 @@
 metering_point_id;metering_point_type;date;quantity;#comment
-150000001500170200;net_consumption;2025-02-28T23:00:00Z;2.740;Cenk = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739) 
+150000001500170200;net_consumption;2025-02-28T23:00:00Z;2.740;CENC = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739) 
 150000001500170200;net_consumption;2025-03-01T23:00:00Z;2.740;
 150000001500170200;net_consumption;2025-03-02T23:00:00Z;2.740;
 150000001500170200;net_consumption;2025-03-03T23:00:00Z;2.740;

--- a/source/geh_calculated_measurements/tests/net_consumption_group_6/scenario_tests/nsg6_up_to_end_simple_scenario_cenk_d15/then/measurements.csv
+++ b/source/geh_calculated_measurements/tests/net_consumption_group_6/scenario_tests/nsg6_up_to_end_simple_scenario_cenk_d15/then/measurements.csv
@@ -1,2 +1,2 @@
 orchestration_type;orchestration_instance_id;transaction_id;transaction_creation_datetime;metering_point_id;metering_point_type;date;quantity;#comment
-net_consumption;00000000-0000-0000-0000-000000000001;[IGNORED];[IGNORED];150000001500170200;net_consumption;2024-12-31T23:00:00Z;2.740;Cenk = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739) 
+net_consumption;00000000-0000-0000-0000-000000000001;[IGNORED];[IGNORED];150000001500170200;net_consumption;2024-12-31T23:00:00Z;2.740;CENC = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739) 

--- a/source/geh_calculated_measurements/tests/net_consumption_group_6/scenario_tests/nsg6_up_to_end_simple_scenario_cenk_d15_multiple_days/then/measurements.csv
+++ b/source/geh_calculated_measurements/tests/net_consumption_group_6/scenario_tests/nsg6_up_to_end_simple_scenario_cenk_d15_multiple_days/then/measurements.csv
@@ -1,4 +1,4 @@
 orchestration_type;orchestration_instance_id;transaction_id;transaction_creation_datetime;metering_point_id;metering_point_type;date;quantity;#comment
-net_consumption;00000000-0000-0000-0000-000000000001;[IGNORED];[IGNORED];150000001500170200;net_consumption;2024-12-31T23:00:00Z;2.740;Cenk = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739) 
-net_consumption;00000000-0000-0000-0000-000000000001;[IGNORED];[IGNORED];150000001500170200;net_consumption;2024-12-30T23:00:00Z;2.740;Cenk = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739)
-net_consumption;00000000-0000-0000-0000-000000000001;[IGNORED];[IGNORED];150000001500170200;net_consumption;2024-12-29T23:00:00Z;2.740;Cenk = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739)
+net_consumption;00000000-0000-0000-0000-000000000001;[IGNORED];[IGNORED];150000001500170200;net_consumption;2024-12-31T23:00:00Z;2.740;CENC = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739) 
+net_consumption;00000000-0000-0000-0000-000000000001;[IGNORED];[IGNORED];150000001500170200;net_consumption;2024-12-30T23:00:00Z;2.740;CENC = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739)
+net_consumption;00000000-0000-0000-0000-000000000001;[IGNORED];[IGNORED];150000001500170200;net_consumption;2024-12-29T23:00:00Z;2.740;CENC = calculated estimated netto consumption ( d07 - d06 / 365 = 2,739)


### PR DESCRIPTION
Update measurement files to replace the term "Cenk" with "CENC" for consistency and accuracy in calculated estimated netto consumption descriptions.