### PR TITLE
Fix filtering of cancelled measurements

### DIFF
--- a/source/dotnet/Measurements.Infrastructure/Persistence/Queries/GetMeasurementsQuery.cs
+++ b/source/dotnet/Measurements.Infrastructure/Persistence/Queries/GetMeasurementsQuery.cs
@@ -24,16 +24,16 @@ public class GetMeasurementsQuery : DatabricksStatement
         return
             $"with most_recent as (" +
             $"select row_number() over (partition by {MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName} order by {MeasurementsGoldConstants.TransactionCreationDatetimeColumnName} desc) as row, " +
-            $"{MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.UnitColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName}, {MeasurementsGoldConstants.QuantityColumnName}, {MeasurementsGoldConstants.QualityColumnName} " +
+            $"{MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.UnitColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName}, {MeasurementsGoldConstants.QuantityColumnName}, {MeasurementsGoldConstants.QualityColumnName}, {MeasurementsGoldConstants.IsCancelledColumnName} " +
             $"from {_databricksSchemaOptions.CatalogName}.{_databricksSchemaOptions.SchemaName}.{MeasurementsGoldConstants.TableName} " +
             $"where {MeasurementsGoldConstants.MeteringPointIdColumnName} = '{_meteringPointId}' " +
             $"and {MeasurementsGoldConstants.ObservationTimeColumnName} >= '{_startDate}' " +
             $"and {MeasurementsGoldConstants.ObservationTimeColumnName} < '{_endDate}' " +
-            $"and {MeasurementsGoldConstants.IsCancelledColumnName} is false " +
             $") " +
             $"select {MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.UnitColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName}, {MeasurementsGoldConstants.QuantityColumnName}, {MeasurementsGoldConstants.QualityColumnName} " +
             $"from most_recent " +
             $"where row = 1 " +
+            $"and not {MeasurementsGoldConstants.IsCancelledColumnName} " +
             $"order by {MeasurementsGoldConstants.ObservationTimeColumnName}";
     }
 }


### PR DESCRIPTION
# Description

Align MeasurementsApi SQL query with the [current_v1 view](https://github.com/Energinet-DataHub/opengeh-measurements/blob/8a20005b55e64401887e444aa364ad02c601d7ab/source/core/src/core/migrations/migration_scripts/20250328121200_fix_cancelled_issue_in_measurements_views.sql#L2)

## References

[current_v1 view](https://github.com/Energinet-DataHub/opengeh-measurements/pull/536)
