### PR TITLE
test: enable parallel execution

### DIFF
--- a/source/core/pyproject.toml
+++ b/source/core/pyproject.toml
@@ -34,6 +34,8 @@ dev = [
     "pytest-bdd-report>=1.0.1",
     "protobuf>=6.30.1",
     "pytest-mock>=3.14.0",
+    "pytest-xdist>=3.6.1",
+    "psutil>=5.9.8",
 ]
 
 [build-system]
@@ -53,6 +55,8 @@ addopts = [
     "-ra",
     "-vv",
     "-s",
+    "-n=auto",
+    "--dist=load",
 ]
 
 [tool.coverage.report]

--- a/source/core/tests/conftest.py
+++ b/source/core/tests/conftest.py
@@ -20,21 +20,21 @@ def pytest_runtest_setup() -> None:
     environment_variables_helpers.set_test_environment_variables()
 
 
+extra_packages = [
+    "org.apache.spark:spark-protobuf_2.12:3.5.4",
+    "org.apache.hadoop:hadoop-azure:3.3.2",
+    "org.apache.hadoop:hadoop-common:3.3.2",
+    "io.delta:delta-spark_2.12:3.1.0",
+    "io.delta:delta-core_2.12:2.3.0",
+]
+session, _ = get_spark_test_session(extra_packages=extra_packages)
+
+
 @pytest.fixture(scope="session")
 def spark(session_mocker: MockerFixture) -> Generator[SparkSession, None, None]:
-    extra_packages = [
-        "org.apache.spark:spark-protobuf_2.12:3.5.4",
-        "org.apache.hadoop:hadoop-azure:3.3.2",
-        "org.apache.hadoop:hadoop-common:3.3.2",
-        "io.delta:delta-spark_2.12:3.1.0",
-        "io.delta:delta-core_2.12:2.3.0",
-    ]
-    session, _ = get_spark_test_session(extra_packages=extra_packages)
     schema_helper.create_schemas(session)
     session_mocker.patch(f"{gold_spark.__name__}.initialize_spark", return_value=session)
-
     yield session
-
     session.stop()
 
 

--- a/source/core/uv.lock
+++ b/source/core/uv.lock
@@ -310,12 +310,14 @@ dev = [
     { name = "commitizen" },
     { name = "mypy" },
     { name = "protobuf" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-bdd" },
     { name = "pytest-bdd-report" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -333,12 +335,14 @@ dev = [
     { name = "commitizen", specifier = ">=4.1.0" },
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "protobuf", specifier = ">=6.30.1" },
+    { name = "psutil", specifier = ">=5.9.8" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-bdd", specifier = ">=8.1.0" },
     { name = "pytest-bdd-report", specifier = ">=1.0.1" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.9.1" },
 ]
 
@@ -511,6 +515,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998 },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612 },
 ]
 
 [[package]]
@@ -1315,6 +1328,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Spark session must be created as a global variable, when used with `pytest-xdist`

<!-- INSERT DESCRIPTION HERE -->

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
