### PR TITLE
Refactor CurrentMeasurements to use measurements_gold schema

### DIFF
--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/common/domain/model/current_measurements.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/common/domain/model/current_measurements.py
@@ -1,4 +1,4 @@
-import pyspark.sql.types as T
+from geh_common.data_products.measurements_core.measurements_gold.current_v1 import current_v1
 from geh_common.pyspark.data_frame_wrapper import DataFrameWrapper
 from pyspark.sql import DataFrame
 
@@ -8,27 +8,7 @@ nullable = True
 class CurrentMeasurements(DataFrameWrapper):
     """All current (latest) measurements. This is a generic type used for multiple types of calculation."""
 
-    schema = T.StructType(
-        [
-            # GSRN (18 characters) that uniquely identifies the metering point
-            # Example: 578710000000000103
-            T.StructField("metering_point_id", T.StringType(), not nullable),
-            #
-            # Example: consumption, production, electrical_heating etc.
-            T.StructField("metering_point_type", T.StringType(), not nullable),
-            #
-            # Energy quantity in kWh for the given observation time.
-            # Example: 1234.534
-            T.StructField("quantity", T.DecimalType(18, 3), not nullable),
-            #
-            #  "missing" | "estimated" | "measured" | "calculated"
-            # Example: measured
-            T.StructField("quality", T.StringType(), not nullable),
-            #
-            # UTC time
-            T.StructField("observation_time", T.TimestampType(), not nullable),
-        ]
-    )
+    schema = current_v1
 
     def __init__(self, df: DataFrame):
         super().__init__(

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/common/infrastructure/current_measurements/repository.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/common/infrastructure/current_measurements/repository.py
@@ -1,4 +1,5 @@
-from pyspark.sql import SparkSession
+from geh_common.testing.dataframes import assert_contract
+from pyspark.sql import DataFrame, SparkSession
 
 from geh_calculated_measurements.common.domain.model.current_measurements import CurrentMeasurements
 from geh_calculated_measurements.common.infrastructure.current_measurements.database_definitions import (
@@ -10,18 +11,18 @@ class Repository:
     def __init__(
         self,
         spark: SparkSession,
-        catalog_name: str | None = None,
+        catalog_name: str,
     ) -> None:
         self._spark = spark
         self._catalog_name = catalog_name
 
-    def _get_full_table_path(self, database_name: str, table_name: str) -> str:
-        if self._catalog_name:
-            return f"{self._catalog_name}.{database_name}.{table_name}"
-        return f"{database_name}.{table_name}"
-
     def read_current_measurements(self) -> CurrentMeasurements:
+        df = self._read()
+        assert_contract(df.schema, CurrentMeasurements.schema)
+        return CurrentMeasurements(df)
+
+    def _read(self) -> DataFrame:
+        """Read table or view. The function is introduced to allow mocking in tests."""
         database_name = MeasurementsGoldDatabaseDefinition.DATABASE_NAME
         table_name = MeasurementsGoldDatabaseDefinition.CURRENT_MEASUREMENTS
-        df = self._spark.table(self._get_full_table_path(database_name, table_name))
-        return CurrentMeasurements(df)
+        return self._spark.read.table(f"{self._catalog_name}.{database_name}.{table_name}")

--- a/source/geh_calculated_measurements/tests/common/infrastructure/current_measurements/test_repository.py
+++ b/source/geh_calculated_measurements/tests/common/infrastructure/current_measurements/test_repository.py
@@ -42,7 +42,7 @@ def valid_df(spark: SparkSession) -> DataFrame:
     return df
 
 
-def test__when_invalid_contract_raises_with_useful_message(
+def test__when_invalid_contract__raises_with_useful_message(
     current_measurements_repository: CurrentMeasurementsRepository,
     valid_df: DataFrame,
     monkeypatch: pytest.MonkeyPatch,

--- a/source/geh_calculated_measurements/tests/common/infrastructure/current_measurements/test_repository.py
+++ b/source/geh_calculated_measurements/tests/common/infrastructure/current_measurements/test_repository.py
@@ -64,7 +64,7 @@ def test__when_invalid_contract__raises_with_useful_message(
         current_measurements_repository.read_current_measurements()
 
 
-def test__when_source_contains_unexpected_columns_returns_data_without_unexpected_column(
+def test__when_source_contains_unexpected_columns__returns_data_without_unexpected_column(
     current_measurements_repository: CurrentMeasurementsRepository,
     valid_df: DataFrame,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Update CurrentMeasurements to utilize the schema from measurements_gold, enhancing data reading in the repository. Adjust tests to ensure compliance with the new schema.

Fixes and improvements:
- Test of bad input schema improved to ensure helpful error message (test__when_invalid_contract_raises_with_useful_message)
- Fixed usage of the wrong duplicate of the contract by replacing it with current_v1 from geh_common
- Ensure that the tests do not potentially break other tests (by stopping modifying shared state - i.e., the delta tables)
- Ensure that the fixture `valid_df` that _claims_ to create valid data frame actually does it
- Make catalog_name ctor arg of repository mandatory as it should always be provided