### PR TITLE
Update geh_common to version 5.6.2 for cleaner test output

### DIFF
--- a/source/geh_calculated_measurements/pyproject.toml
+++ b/source/geh_calculated_measurements/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "azure-monitor-opentelemetry==1.6.4",
     "configargparse==1.7.0",
     "delta-spark==3.2.0",
-    "geh_common @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@geh_common_5.6.1#subdirectory=source/geh_common",
+    "geh_common @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@geh_common_5.6.2#subdirectory=source/geh_common",
     "pydantic-settings>=2.7.1",
     "pyspark==3.5.1",
     "python-dateutil==2.8.2",

--- a/source/geh_calculated_measurements/uv.lock
+++ b/source/geh_calculated_measurements/uv.lock
@@ -477,7 +477,7 @@ requires-dist = [
     { name = "azure-monitor-opentelemetry", specifier = "==1.6.4" },
     { name = "configargparse", specifier = "==1.7.0" },
     { name = "delta-spark", specifier = "==3.2.0" },
-    { name = "geh-common", git = "https://github.com/Energinet-DataHub/opengeh-python-packages?subdirectory=source%2Fgeh_common&rev=geh_common_5.6.1" },
+    { name = "geh-common", git = "https://github.com/Energinet-DataHub/opengeh-python-packages?subdirectory=source%2Fgeh_common&rev=geh_common_5.6.2" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "pyspark", specifier = "==3.5.1" },
     { name = "python-dateutil", specifier = "==2.8.2" },
@@ -497,8 +497,8 @@ dev = [
 
 [[package]]
 name = "geh-common"
-version = "5.6.1"
-source = { git = "https://github.com/Energinet-DataHub/opengeh-python-packages?subdirectory=source%2Fgeh_common&rev=geh_common_5.6.1#9ae0ef58ce4c7c678ccbd24a38142dcc6fa7d19d" }
+version = "5.6.2"
+source = { git = "https://github.com/Energinet-DataHub/opengeh-python-packages?subdirectory=source%2Fgeh_common&rev=geh_common_5.6.2#eef28712072cfc1e55ecc42e162fa03c3f452126" }
 dependencies = [
     { name = "azure-core" },
     { name = "azure-identity" },


### PR DESCRIPTION
Upgrade geh_common to the latest version to reduce noise in test output during testing.