### PR TITLE
fix: Handle unknown protobuf message

### DIFF
--- a/source/core/src/core/silver/infrastructure/protobuf/version_message.py
+++ b/source/core/src/core/silver/infrastructure/protobuf/version_message.py
@@ -10,12 +10,12 @@ def with_version(protobuf_message: DataFrame) -> DataFrame:
     message_name = "VersionMessage"
     message_alias = "version_message"
 
+    options = {"mode": "PERMISSIVE"}
+
     protobuf_message = protobuf_message.withColumn(
         message_alias,
         from_protobuf(
-            protobuf_message.value,
-            message_name,
-            descFilePath=DescriptorFilePaths.VersionMessage,
+            protobuf_message.value, message_name, descFilePath=DescriptorFilePaths.VersionMessage, options=options
         ),
     )
 

--- a/source/core/tests/helpers/protobuf_helper.py
+++ b/source/core/tests/helpers/protobuf_helper.py
@@ -1,3 +1,5 @@
+import random
+
 import pyspark.sql.functions as F
 from pyspark.sql import DataFrame
 from pyspark.sql.protobuf.functions import from_protobuf
@@ -34,3 +36,7 @@ def unpack_brs021_forward_metered_data_notify_v1(brs021_forward_metered_data_not
             Brs021ForwardMeteredDataNotifyV1ColumnNames.orchestration_instance_id
         ),
     )
+
+
+def generate_random_binary() -> bytes:
+    return bytes(random.getrandbits(8) for _ in range(18))

--- a/source/core/tests/unit_tests/silver/infrastructure/protobuf/test_version_message.py
+++ b/source/core/tests/unit_tests/silver/infrastructure/protobuf/test_version_message.py
@@ -1,6 +1,7 @@
 from pyspark.sql import SparkSession
 
 import core.silver.infrastructure.protobuf.version_message as version_message
+import tests.helpers.protobuf_helper as protobuf_helper
 from tests.helpers.builders.submitted_transactions_builder import SubmittedTransactionsBuilder, ValueBuilder
 
 
@@ -16,3 +17,18 @@ def test__with_version__adds_version_column_to_dataframe(spark: SparkSession) ->
     # Assert
     actual_row = actual.collect()[0]
     assert actual_row["version"] == str(version)
+
+
+def test__with_version__when_protobuf_message_cannot_be_parsed__should_return_invalid_dataframe(
+    spark: SparkSession,
+) -> None:
+    # Arrange
+    value = protobuf_helper.generate_random_binary()
+    protobuf_message = SubmittedTransactionsBuilder(spark).add_row(value=value).build()
+
+    # Act
+    actual = version_message.with_version(protobuf_message)
+
+    # Assert
+    actual_row = actual.collect()[0]
+    assert actual_row["version"] is None


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->
We found out that when receiving an unknonwn protobuf message, the stream will fail when trying to extract the version.

Changing mode to "PERMISSIVE", which means that the default value will then be `None`.

The message will go to the `invalid_submitted_transactions` table.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
