### PR TITLE
[MeasurementsApi] Enable authentication on controller

### DIFF
--- a/source/dotnet/Measurements.WebApi/Controllers/MeasurementsController.cs
+++ b/source/dotnet/Measurements.WebApi/Controllers/MeasurementsController.cs
@@ -2,17 +2,18 @@
 using Energinet.DataHub.Measurements.Application.Handlers;
 using Energinet.DataHub.Measurements.Application.Requests;
 using Energinet.DataHub.Measurements.Infrastructure.Serialization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Energinet.DataHub.Measurements.WebApi.Controllers;
 
 [ApiController]
+[Authorize]
 [Route("measurements")]
 public class MeasurementsController(IMeasurementsHandler measurementsHandler)
     : ControllerBase
 {
     [HttpGet]
-    // [Authorize] TODO: Uncomment when authentication is implemented in all clients
     [Route("forPeriod")]
     public async Task<IActionResult> GetMeasurementsAsync([FromQuery] GetMeasurementRequest request)
     {
@@ -30,7 +31,6 @@ public class MeasurementsController(IMeasurementsHandler measurementsHandler)
     }
 
     [HttpGet]
-    // [Authorize] TODO: Uncomment when authentication is implemented in all clients
     [Route("aggregatedByMonth")]
     public async Task<IActionResult> GetAggregatedMeasurementsAsync([FromQuery] GetAggregatedMeasurementsForMonthRequest request)
     {


### PR DESCRIPTION
# Description

Authentication was prepared in both BFF and API in earlier PRs, now we enforce authentication of requests to the controller

## References

https://github.com/Energinet-DataHub/team-volt/issues/1079
