### PR TITLE
Fix typo in spark_session.py configuration

### DIFF
--- a/source/core/src/core/silver/infrastructure/config/spark_session.py
+++ b/source/core/src/core/silver/infrastructure/config/spark_session.py
@@ -9,7 +9,7 @@ def initialize_spark() -> SparkSession:
         SparkConf(loadDefaults=True)
         .set("spark.sql.session.timeZone", "UTC")
         .set("spark.databricks.io.cache.enabled", "True")
-        .set("spaprk.sql.shuffle.partitions", "200")
+        .set("spark.sql.shuffle.partitions", "200")
         .set("spark.sql.files.maxPartitionBytes", str(int(max_partition_bytes_in_mb * 1024 * 1024)) + "b")
     )
     return SparkSession.builder.config(conf=spark_conf).getOrCreate()


### PR DESCRIPTION
Corrected a typo in the Spark configuration setting for shuffle partitions.