### PR TITLE
[MeasurementsApi] ContainsUpdatedValues added to MeasurementAggregationDto

### DIFF
--- a/docs/Measurements.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/Measurements.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Measurements.Client Release Notes
 
+## Version 2.3.0
+
+- ContainsUpdatedValues added to MeasurementAggregationDto.
+
 ## Version 2.2.0
 
 - Added method to get aggregated measurements for a month.

--- a/source/dotnet/Measurements.Abstractions/Api/Models/AggregatedMeasurements.cs
+++ b/source/dotnet/Measurements.Abstractions/Api/Models/AggregatedMeasurements.cs
@@ -1,3 +1,3 @@
 ﻿namespace Energinet.DataHub.Measurements.Abstractions.Api.Models;
 
-public sealed record MeasurementAggregationDto(DateOnly Date, decimal Quantity, Quality Quality, bool MissingValues);
+public sealed record MeasurementAggregationDto(DateOnly Date, decimal Quantity, Quality Quality, bool MissingValues, bool ContainsUpdatedValues);

--- a/source/dotnet/Measurements.Abstractions/Measurements.Abstractions.csproj
+++ b/source/dotnet/Measurements.Abstractions/Measurements.Abstractions.csproj
@@ -7,7 +7,7 @@
 
     <PropertyGroup>
         <PackageId>Energinet.DataHub.Measurements.Abstractions</PackageId>
-        <PackageVersion>2.2.0$(VersionSuffix)</PackageVersion>
+        <PackageVersion>2.3.0$(VersionSuffix)</PackageVersion>
         <Title>DH3 Measurements Abstractions library</Title>
         <Company>Energinet-DataHub</Company>
         <Authors>Energinet-DataHub</Authors>

--- a/source/dotnet/Measurements.Application/Persistence/AggregatedMeasurementsResult.cs
+++ b/source/dotnet/Measurements.Application/Persistence/AggregatedMeasurementsResult.cs
@@ -18,4 +18,6 @@ public class AggregatedMeasurementsResult(ExpandoObject raw)
     public object[] Resolutions => _raw.resolutions;
 
     public long PointCount => _raw.point_count;
+
+    public long ObservationUpdates => _raw.observation_updates;
 }

--- a/source/dotnet/Measurements.Application/Responses/GetAggregatedMeasurementsResponse.cs
+++ b/source/dotnet/Measurements.Application/Responses/GetAggregatedMeasurementsResponse.cs
@@ -27,7 +27,7 @@ public class GetAggregatedMeasurementsResponse
                 new MeasurementAggregation(
                     measurement.MinObservationTime.ToDateOnly(),
                     measurement.Quantity,
-                    measurement.Qualities.Select(quality => QualityParser.ParseQuality((string)quality)).Min(),
+                    SetQuality(measurement),
                     SetMissingValuesForAggregation(measurement),
                     SetContainsUpdatedValues(measurement)))
             .ToList();
@@ -35,6 +35,13 @@ public class GetAggregatedMeasurementsResponse
         return measurementAggregations.Count <= 0
             ? throw new MeasurementsNotFoundDuringPeriodException()
             : new GetAggregatedMeasurementsResponse(measurementAggregations);
+    }
+
+    private static Quality SetQuality(AggregatedMeasurementsResult aggregatedMeasurementsResult)
+    {
+        return aggregatedMeasurementsResult.Qualities
+            .Select(quality => QualityParser.ParseQuality((string)quality))
+            .Min();
     }
 
     private static bool SetMissingValuesForAggregation(AggregatedMeasurementsResult aggregatedMeasurements)

--- a/source/dotnet/Measurements.Application/Responses/GetAggregatedMeasurementsResponse.cs
+++ b/source/dotnet/Measurements.Application/Responses/GetAggregatedMeasurementsResponse.cs
@@ -28,7 +28,8 @@ public class GetAggregatedMeasurementsResponse
                     measurement.MinObservationTime.ToDateOnly(),
                     measurement.Quantity,
                     measurement.Qualities.Select(quality => QualityParser.ParseQuality((string)quality)).Min(),
-                    SetMissingValuesForAggregation(measurement)))
+                    SetMissingValuesForAggregation(measurement),
+                    SetContainsUpdatedValues(measurement)))
             .ToList();
 
         return measurementAggregations.Count <= 0
@@ -65,5 +66,10 @@ public class GetAggregatedMeasurementsResponse
             _ => throw new ArgumentOutOfRangeException(resolution.ToString()),
         };
         return expectedPointCount;
+    }
+
+    private static bool SetContainsUpdatedValues(AggregatedMeasurementsResult aggregatedMeasurementsResult)
+    {
+        return aggregatedMeasurementsResult.ObservationUpdates > 1;
     }
 }

--- a/source/dotnet/Measurements.Client/Measurements.Client.csproj
+++ b/source/dotnet/Measurements.Client/Measurements.Client.csproj
@@ -7,7 +7,7 @@
 
     <PropertyGroup>
         <PackageId>Energinet.DataHub.Measurements.Client</PackageId>
-        <PackageVersion>2.2.0$(VersionSuffix)</PackageVersion>
+        <PackageVersion>2.3.0$(VersionSuffix)</PackageVersion>
         <Title>DH3 Measurements Client library</Title>
         <Company>Energinet-DataHub</Company>
         <Authors>Energinet-DataHub</Authors>

--- a/source/dotnet/Measurements.Domain/MeasurementAggregation.cs
+++ b/source/dotnet/Measurements.Domain/MeasurementAggregation.cs
@@ -1,3 +1,3 @@
 ﻿namespace Energinet.DataHub.Measurements.Domain;
 
-public record MeasurementAggregation(DateOnly Date, decimal Quantity, Quality Quality, bool MissingValues);
+public record MeasurementAggregation(DateOnly Date, decimal Quantity, Quality Quality, bool MissingValues, bool ContainsUpdatedValues);

--- a/source/dotnet/Measurements.Infrastructure/Persistence/Queries/AggregatedMeasurementsConstants.cs
+++ b/source/dotnet/Measurements.Infrastructure/Persistence/Queries/AggregatedMeasurementsConstants.cs
@@ -8,5 +8,5 @@ public class AggregatedMeasurementsConstants
     public const string Qualities = "qualities";
     public const string Resolutions = "resolutions";
     public const string PointCount = "point_count";
-    public const string ObservationUpdates = "ObservationUpdates";
+    public const string ObservationUpdates = "observation_updates";
 }

--- a/source/dotnet/Measurements.Infrastructure/Persistence/Queries/AggregatedMeasurementsConstants.cs
+++ b/source/dotnet/Measurements.Infrastructure/Persistence/Queries/AggregatedMeasurementsConstants.cs
@@ -8,4 +8,5 @@ public class AggregatedMeasurementsConstants
     public const string Qualities = "qualities";
     public const string Resolutions = "resolutions";
     public const string PointCount = "point_count";
+    public const string ObservationUpdates = "ObservationUpdates";
 }

--- a/source/dotnet/Measurements.Infrastructure/Persistence/Queries/GetAggregatedMeasurementsQuery.cs
+++ b/source/dotnet/Measurements.Infrastructure/Persistence/Queries/GetAggregatedMeasurementsQuery.cs
@@ -25,6 +25,7 @@ public class GetAggregatedMeasurementsQuery : DatabricksStatement
         return
             $"with most_recent as (" +
             $"select row_number() over (partition by {MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName} order by {MeasurementsGoldConstants.TransactionCreationDatetimeColumnName} desc) as row, " +
+            $"count(*) over (partition by {MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName}) as row_count, " +
             $"{MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.UnitColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName}, {MeasurementsGoldConstants.QuantityColumnName}, {MeasurementsGoldConstants.QualityColumnName}, {MeasurementsGoldConstants.ResolutionColumnName}, {MeasurementsGoldConstants.IsCancelledColumnName} " +
             $"from {_databricksSchemaOptions.CatalogName}.{_databricksSchemaOptions.SchemaName}.{MeasurementsGoldConstants.TableName} " +
             $"where {MeasurementsGoldConstants.MeteringPointIdColumnName} = :{QueryParameterConstants.MeteringPointIdParameter} " +
@@ -37,7 +38,8 @@ public class GetAggregatedMeasurementsQuery : DatabricksStatement
             $"sum({MeasurementsGoldConstants.QuantityColumnName}) as {AggregatedMeasurementsConstants.AggregatedQuantity}, " +
             $"array_agg(distinct({MeasurementsGoldConstants.QualityColumnName})) as {AggregatedMeasurementsConstants.Qualities}, " +
             $"array_agg(distinct({MeasurementsGoldConstants.ResolutionColumnName})) as {AggregatedMeasurementsConstants.Resolutions}, " +
-            $"count({MeasurementsGoldConstants.ObservationTimeColumnName}) as {AggregatedMeasurementsConstants.PointCount} " +
+            $"count({MeasurementsGoldConstants.ObservationTimeColumnName}) as {AggregatedMeasurementsConstants.PointCount}, " +
+            $"max(row_count) as {AggregatedMeasurementsConstants.ObservationUpdates}" +
             $"from most_recent " +
             $"where row = 1 " +
             $"and not {MeasurementsGoldConstants.IsCancelledColumnName} " +

--- a/source/dotnet/Measurements.Infrastructure/Persistence/Queries/GetAggregatedMeasurementsQuery.cs
+++ b/source/dotnet/Measurements.Infrastructure/Persistence/Queries/GetAggregatedMeasurementsQuery.cs
@@ -39,7 +39,7 @@ public class GetAggregatedMeasurementsQuery : DatabricksStatement
             $"array_agg(distinct({MeasurementsGoldConstants.QualityColumnName})) as {AggregatedMeasurementsConstants.Qualities}, " +
             $"array_agg(distinct({MeasurementsGoldConstants.ResolutionColumnName})) as {AggregatedMeasurementsConstants.Resolutions}, " +
             $"count({MeasurementsGoldConstants.ObservationTimeColumnName}) as {AggregatedMeasurementsConstants.PointCount}, " +
-            $"max(row_count) as {AggregatedMeasurementsConstants.ObservationUpdates}" +
+            $"max(row_count) as {AggregatedMeasurementsConstants.ObservationUpdates} " +
             $"from most_recent " +
             $"where row = 1 " +
             $"and not {MeasurementsGoldConstants.IsCancelledColumnName} " +

--- a/source/dotnet/Measurements.UnitTests/Infrastructure/Persistence/Queries/GetAggregatedMeasurementsQueryTests.cs
+++ b/source/dotnet/Measurements.UnitTests/Infrastructure/Persistence/Queries/GetAggregatedMeasurementsQueryTests.cs
@@ -31,6 +31,7 @@ public class GetAggregatedMeasurementsQueryTests
     {
         return $"with most_recent as (" +
                $"select row_number() over (partition by {MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName} order by {MeasurementsGoldConstants.TransactionCreationDatetimeColumnName} desc) as row, " +
+               $"count(*) over (partition by {MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName}) as row_count, " +
                $"{MeasurementsGoldConstants.MeteringPointIdColumnName}, {MeasurementsGoldConstants.UnitColumnName}, {MeasurementsGoldConstants.ObservationTimeColumnName}, {MeasurementsGoldConstants.QuantityColumnName}, {MeasurementsGoldConstants.QualityColumnName}, {MeasurementsGoldConstants.ResolutionColumnName}, {MeasurementsGoldConstants.IsCancelledColumnName} " +
                $"from {databricksSchemaOptions.CatalogName}.{databricksSchemaOptions.SchemaName}.{MeasurementsGoldConstants.TableName} " +
                $"where {MeasurementsGoldConstants.MeteringPointIdColumnName} = :{QueryParameterConstants.MeteringPointIdParameter} " +
@@ -43,7 +44,8 @@ public class GetAggregatedMeasurementsQueryTests
                $"sum({MeasurementsGoldConstants.QuantityColumnName}) as {AggregatedMeasurementsConstants.AggregatedQuantity}, " +
                $"array_agg(distinct({MeasurementsGoldConstants.QualityColumnName})) as {AggregatedMeasurementsConstants.Qualities}, " +
                $"array_agg(distinct({MeasurementsGoldConstants.ResolutionColumnName})) as {AggregatedMeasurementsConstants.Resolutions}, " +
-               $"count({MeasurementsGoldConstants.ObservationTimeColumnName}) as {AggregatedMeasurementsConstants.PointCount} " +
+               $"count({MeasurementsGoldConstants.ObservationTimeColumnName}) as {AggregatedMeasurementsConstants.PointCount}, " +
+               $"max(row_count) as {AggregatedMeasurementsConstants.ObservationUpdates}" +
                $"from most_recent " +
                $"where row = 1 " +
                $"and not {MeasurementsGoldConstants.IsCancelledColumnName} " +

--- a/source/dotnet/Measurements.UnitTests/Infrastructure/Persistence/Queries/GetAggregatedMeasurementsQueryTests.cs
+++ b/source/dotnet/Measurements.UnitTests/Infrastructure/Persistence/Queries/GetAggregatedMeasurementsQueryTests.cs
@@ -45,7 +45,7 @@ public class GetAggregatedMeasurementsQueryTests
                $"array_agg(distinct({MeasurementsGoldConstants.QualityColumnName})) as {AggregatedMeasurementsConstants.Qualities}, " +
                $"array_agg(distinct({MeasurementsGoldConstants.ResolutionColumnName})) as {AggregatedMeasurementsConstants.Resolutions}, " +
                $"count({MeasurementsGoldConstants.ObservationTimeColumnName}) as {AggregatedMeasurementsConstants.PointCount}, " +
-               $"max(row_count) as {AggregatedMeasurementsConstants.ObservationUpdates}" +
+               $"max(row_count) as {AggregatedMeasurementsConstants.ObservationUpdates} " +
                $"from most_recent " +
                $"where row = 1 " +
                $"and not {MeasurementsGoldConstants.IsCancelledColumnName} " +


### PR DESCRIPTION
# Description

The UI needs an indication of whether an aggregation contains updated values of single observations:
![image](https://github.com/user-attachments/assets/6e3c2de7-3a44-487c-b68e-ae965e2425b0)

## References

http://github.com/Energinet-DataHub/team-volt/issues/1109

