### PR TITLE
Specified ObservationTime as a pruning filter

### DIFF
--- a/source/core/src/core/gold/infrastructure/repositories/gold_measurements_repository.py
+++ b/source/core/src/core/gold/infrastructure/repositories/gold_measurements_repository.py
@@ -21,7 +21,10 @@ class GoldMeasurementsRepository:
         :param gold_measurements: DataFrame containing the data to be appended.
         """
         orchestration_type_filters = self._get_possible_orchestration_types_for_stream(query_name)
-        clustering_keys_to_filter = [GoldMeasurementsColumnNames.transaction_creation_datetime]
+        clustering_keys_to_filter = [
+            GoldMeasurementsColumnNames.transaction_creation_datetime,
+            GoldMeasurementsColumnNames.observation_time,
+        ]
 
         delta_table_helper.append_if_not_exists(
             self.spark,


### PR DESCRIPTION
# Description

After seeing success with using Transaction Creation Datetime for reducing searchspace of our gold measurements merge, this PR introduces the same but for observation_time. The code already supports multiple pruning filters, so this should ensure that any file in gold read has to both contain the date of transaction_creation_datetime and observation_time that we are looking for.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
