### PR TITLE
fix: Migration runner

### DIFF
--- a/source/core/src/core/migrations/migrations_runner.py
+++ b/source/core/src/core/migrations/migrations_runner.py
@@ -42,7 +42,7 @@ def _stop_job_runs() -> None:
     for job in jobs:
         print(f"Finding job run for job: {job}")  # noqa: T201
         job_id = databricks_api_client.get_job_id(job)
-        run_id = databricks_api_client.get_latest_job_run(job_id).run_id
+        run_id = databricks_api_client.get_latest_job_run_id(job_id)
 
         if run_id is None:
             print(f"No job runs found for job {job}")  # noqa: T201

--- a/source/core/tests/unit_tests/migrations/test_migrations_runner.py
+++ b/source/core/tests/unit_tests/migrations/test_migrations_runner.py
@@ -42,5 +42,5 @@ def test__stop_job_runs__calls_expected(mocker: MockerFixture):
         databricks_token=mock_settings_instance.databricks_token,
     )
     assert mock_client_instance.get_job_id.call_count == 2
-    assert mock_client_instance.get_latest_job_run.call_count == 2
+    assert mock_client_instance.get_latest_job_run_id.call_count == 2
     assert mock_client_instance.cancel_job_run.call_count == 2


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->

Migration runner was using a function which doesn't exist.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
