### PR TITLE
Measurements/Core/Feat: Add other Issuers in MeasurementsClient

### DIFF
--- a/docs/Measurements.Client/ReleaseNotes/ReleaseNotes.md
+++ b/docs/Measurements.Client/ReleaseNotes/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Measurements.Client Release Notes
 
+## Version 7.2.0
+
+- Added the possibility of Authorizing using B2C in MeasurementsApi.
+
 ## Version 7.1.1
 
 - fix link to documentation in package README

--- a/source/dotnet/Measurements.Abstractions/Measurements.Abstractions.csproj
+++ b/source/dotnet/Measurements.Abstractions/Measurements.Abstractions.csproj
@@ -7,7 +7,7 @@
 
     <PropertyGroup>
         <PackageId>Energinet.DataHub.Measurements.Abstractions</PackageId>
-        <PackageVersion>7.1.1$(VersionSuffix)</PackageVersion>
+        <PackageVersion>7.2.0$(VersionSuffix)</PackageVersion>
         <Title>DH3 Measurements Abstractions library</Title>
         <Company>Energinet-DataHub</Company>
         <Authors>Energinet-DataHub</Authors>

--- a/source/dotnet/Measurements.Application/Extensions/Options/AzureADAuthenticationOptions.cs
+++ b/source/dotnet/Measurements.Application/Extensions/Options/AzureADAuthenticationOptions.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Energinet.DataHub.Measurements.Application.Extensions.Options;
+
+/// <summary>
+/// Contains options for validating the JWT bearer tokens that must be sent as
+/// part of any http request for protected http endpoints.
+/// </summary>
+public class AzureAdAuthenticationOptions
+{
+    public const string SectionName = "AzureAD";
+
+    [Required(AllowEmptyStrings = false)]
+    public string TenantId { get; init; } = string.Empty;
+
+    [Required(AllowEmptyStrings = false)]
+    public string Audience { get; init; } = string.Empty;
+
+    [Required(AllowEmptyStrings = false)]
+    public string Authority { get; init; } = string.Empty;
+}

--- a/source/dotnet/Measurements.Application/Extensions/Options/AzureADAuthenticationOptions.cs
+++ b/source/dotnet/Measurements.Application/Extensions/Options/AzureADAuthenticationOptions.cs
@@ -8,7 +8,7 @@ namespace Energinet.DataHub.Measurements.Application.Extensions.Options;
 /// </summary>
 public class AzureAdAuthenticationOptions
 {
-    public const string SectionName = "AzureAD";
+    public const string SectionName = "AzureAd";
 
     [Required(AllowEmptyStrings = false)]
     public string TenantId { get; init; } = string.Empty;

--- a/source/dotnet/Measurements.Application/Extensions/Options/AzureADAuthenticationOptions.cs
+++ b/source/dotnet/Measurements.Application/Extensions/Options/AzureADAuthenticationOptions.cs
@@ -14,5 +14,5 @@ public class AzureAdAuthenticationOptions
     public string TenantId { get; init; } = string.Empty;
 
     [Required(AllowEmptyStrings = false)]
-    public string Audience { get; init; } = string.Empty;
+    public string ResourceId { get; init; } = string.Empty;
 }

--- a/source/dotnet/Measurements.Application/Extensions/Options/AzureADAuthenticationOptions.cs
+++ b/source/dotnet/Measurements.Application/Extensions/Options/AzureADAuthenticationOptions.cs
@@ -15,7 +15,4 @@ public class AzureAdAuthenticationOptions
 
     [Required(AllowEmptyStrings = false)]
     public string Audience { get; init; } = string.Empty;
-
-    [Required(AllowEmptyStrings = false)]
-    public string Authority { get; init; } = string.Empty;
 }

--- a/source/dotnet/Measurements.Application/Extensions/Options/B2CAuthenticationOptions.cs
+++ b/source/dotnet/Measurements.Application/Extensions/Options/B2CAuthenticationOptions.cs
@@ -8,7 +8,7 @@ namespace Energinet.DataHub.Measurements.Application.Extensions.Options;
 /// </summary>
 public class B2CAuthenticationOptions
 {
-    public const string SectionName = "AzureAd";
+    public const string SectionName = "B2CAuthentication";
 
     [Required(AllowEmptyStrings = false)]
     public string TenantId { get; init; } = string.Empty;

--- a/source/dotnet/Measurements.Application/Extensions/Options/B2CAuthenticationOptions.cs
+++ b/source/dotnet/Measurements.Application/Extensions/Options/B2CAuthenticationOptions.cs
@@ -6,7 +6,7 @@ namespace Energinet.DataHub.Measurements.Application.Extensions.Options;
 /// Contains options for validating the JWT bearer tokens that must be sent as
 /// part of any http request for protected http endpoints.
 /// </summary>
-public class AzureAdAuthenticationOptions
+public class B2CAuthenticationOptions
 {
     public const string SectionName = "AzureAd";
 

--- a/source/dotnet/Measurements.Application/Extensions/Options/EntraAuthenticationOptions.cs
+++ b/source/dotnet/Measurements.Application/Extensions/Options/EntraAuthenticationOptions.cs
@@ -6,7 +6,7 @@ namespace Energinet.DataHub.Measurements.Application.Extensions.Options;
 /// Contains options for validating the JWT bearer tokens that must be sent as
 /// part of any http request for protected http endpoints.
 /// </summary>
-public class AuthenticationOptions
+public class EntraAuthenticationOptions
 {
     public const string SectionName = "Auth";
 

--- a/source/dotnet/Measurements.Client.IntegrationTests/Fixture/MeasurementsClientFixture.cs
+++ b/source/dotnet/Measurements.Client.IntegrationTests/Fixture/MeasurementsClientFixture.cs
@@ -72,8 +72,8 @@ public sealed class MeasurementsClientFixture : IAsyncLifetime
                     [$"{DatabricksSqlStatementOptions.DatabricksOptions}:{nameof(DatabricksSqlStatementOptions.WarehouseId)}"] = IntegrationTestConfiguration.DatabricksSettings.WarehouseId,
                     [$"{DatabricksSchemaOptions.SectionName}:{nameof(DatabricksSchemaOptions.SchemaName)}"] = DatabricksSchemaManager.SchemaName,
                     [$"{DatabricksSchemaOptions.SectionName}:{nameof(DatabricksSchemaOptions.CatalogName)}"] = CatalogName,
-                    [$"{AuthenticationOptions.SectionName}:{nameof(AuthenticationOptions.ApplicationIdUri)}"] = ApplicationIdUri,
-                    [$"{AuthenticationOptions.SectionName}:{nameof(AuthenticationOptions.Issuer)}"] = Issuer,
+                    [$"{EntraAuthenticationOptions.SectionName}:{nameof(EntraAuthenticationOptions.ApplicationIdUri)}"] = ApplicationIdUri,
+                    [$"{EntraAuthenticationOptions.SectionName}:{nameof(EntraAuthenticationOptions.Issuer)}"] = Issuer,
                 });
             })
             .UseStartup<Startup>()

--- a/source/dotnet/Measurements.Client/Extensions/DependencyInjection/ClientExtensions.cs
+++ b/source/dotnet/Measurements.Client/Extensions/DependencyInjection/ClientExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Identity;
+﻿using Azure.Core;
+using Azure.Identity;
 using Energinet.DataHub.Measurements.Client.Authentication;
 using Energinet.DataHub.Measurements.Client.Extensions.Options;
 using Energinet.DataHub.Measurements.Client.ResponseParsers;
@@ -13,9 +14,9 @@ namespace Energinet.DataHub.Measurements.Client.Extensions.DependencyInjection;
 public static class ClientExtensions
 {
     /// <summary>
-    /// Register Measurement Client for use in application.
+    /// Register Measurement Client for use in the application.
     /// </summary>
-    public static IServiceCollection AddMeasurementsClient(this IServiceCollection services)
+    public static IServiceCollection AddMeasurementsClient(this IServiceCollection services, TokenCredential? credential = null)
     {
         services
             .AddOptions<MeasurementHttpClientOptions>()
@@ -24,10 +25,9 @@ public static class ClientExtensions
 
         services.AddSingleton<IAuthorizationHeaderProvider>(serviceProvider =>
         {
-            var credential = new DefaultAzureCredential();
             var options = serviceProvider.GetRequiredService<IOptions<MeasurementHttpClientOptions>>().Value;
 
-            return new AuthorizationHeaderProvider(credential, options.ApplicationIdUri);
+            return new AuthorizationHeaderProvider(credential ?? new DefaultAzureCredential(), options.ApplicationIdUri);
         });
 
         services.AddHttpClient(MeasurementsHttpClientNames.MeasurementsApi, (serviceProvider, httpClient) =>

--- a/source/dotnet/Measurements.Client/Measurements.Client.csproj
+++ b/source/dotnet/Measurements.Client/Measurements.Client.csproj
@@ -7,7 +7,7 @@
 
     <PropertyGroup>
         <PackageId>Energinet.DataHub.Measurements.Client</PackageId>
-        <PackageVersion>7.1.1$(VersionSuffix)</PackageVersion>
+        <PackageVersion>7.2.0$(VersionSuffix)</PackageVersion>
         <Title>DH3 Measurements Client library</Title>
         <Company>Energinet-DataHub</Company>
         <Authors>Energinet-DataHub</Authors>

--- a/source/dotnet/Measurements.WebApi.IntegrationTests/Fixtures/WebApiFixture.cs
+++ b/source/dotnet/Measurements.WebApi.IntegrationTests/Fixtures/WebApiFixture.cs
@@ -77,8 +77,8 @@ public class WebApiFixture : WebApplicationFactory<Program>, IAsyncLifetime
         builder.UseSetting($"{DatabricksSqlStatementOptions.DatabricksOptions}:{nameof(DatabricksSqlStatementOptions.WarehouseId)}", IntegrationTestConfiguration.DatabricksSettings.WarehouseId);
         builder.UseSetting($"{DatabricksSchemaOptions.SectionName}:{nameof(DatabricksSchemaOptions.SchemaName)}", DatabricksSchemaManager.SchemaName);
         builder.UseSetting($"{DatabricksSchemaOptions.SectionName}:{nameof(DatabricksSchemaOptions.CatalogName)}", CatalogName);
-        builder.UseSetting($"{AuthenticationOptions.SectionName}:{nameof(AuthenticationOptions.ApplicationIdUri)}", ApplicationIdUri);
-        builder.UseSetting($"{AuthenticationOptions.SectionName}:{nameof(AuthenticationOptions.Issuer)}", Issuer);
+        builder.UseSetting($"{EntraAuthenticationOptions.SectionName}:{nameof(EntraAuthenticationOptions.ApplicationIdUri)}", ApplicationIdUri);
+        builder.UseSetting($"{EntraAuthenticationOptions.SectionName}:{nameof(EntraAuthenticationOptions.Issuer)}", Issuer);
     }
 
     private AuthenticationHeaderValue CreateAuthorizationHeader(string applicationIdUri = ApplicationIdUri)

--- a/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
+++ b/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
@@ -16,24 +16,21 @@ public static class AuthenticationExtensions
             .Get<AzureAdAuthenticationOptions>();
         var authority = $"https://login.microsoftonline.com/{azureAdOptions?.TenantId}/v2.0";
 
-        // Add authentication for Entra ID
-        services.AddAuthentication().AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
-        {
-            options.Authority = entraAuthenticationOptions?.Issuer;
-            options.Audience = entraAuthenticationOptions?.ApplicationIdUri;
-            options.TokenValidationParameters = new TokenValidationParameters
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
             {
-                ValidateAudience = true,
-                ValidateIssuer = true,
-            };
-        });
-
-        // Add authentication for Azure AD
-        services.AddAuthentication()
-            .AddJwtBearer(x =>
+                options.Authority = entraAuthenticationOptions?.Issuer;
+                options.Audience = entraAuthenticationOptions?.ApplicationIdUri;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateAudience = true,
+                    ValidateIssuer = true,
+                };
+            })
+            .AddJwtBearer("AzureAD", options =>
             {
-                x.Audience = azureAdOptions?.Audience;
-                x.Authority = authority;
+                options.Audience = azureAdOptions?.Audience;
+                options.Authority = authority;
             });
 
         return services;

--- a/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
+++ b/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Energinet.DataHub.Measurements.Application.Extensions.Options;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.IdentityModel.Protocols.Configuration;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Energinet.DataHub.Measurements.WebApi.Extensions.DependencyInjection;

--- a/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
+++ b/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
@@ -29,7 +29,7 @@ public static class AuthenticationExtensions
             })
             .AddJwtBearer("AzureAD", options =>
             {
-                options.Audience = azureAdOptions?.Audience;
+                options.Audience = azureAdOptions?.ResourceId;
                 options.Authority = authority;
             });
 

--- a/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
+++ b/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
@@ -14,6 +14,7 @@ public static class AuthenticationExtensions
         var azureAdOptions = configuration
             .GetSection(AzureAdAuthenticationOptions.SectionName)
             .Get<AzureAdAuthenticationOptions>();
+        var authority = $"https://login.microsoftonline.com/{azureAdOptions?.TenantId}/v2.0";
 
         // Add authentication for Entra ID
         services.AddAuthentication().AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
@@ -30,7 +31,7 @@ public static class AuthenticationExtensions
         // Add authentication for Azure AD
         services.AddAuthentication().AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
         {
-            options.Authority = azureAdOptions?.Authority;
+            options.Authority = authority;
             options.Audience = azureAdOptions?.Audience;
         });
 

--- a/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
+++ b/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
@@ -27,7 +27,7 @@ public static class AuthenticationExtensions
                     ValidateIssuer = true,
                 };
             })
-            .AddJwtBearer("AzureAD", options =>
+            .AddJwtBearer("B2C", options =>
             {
                 options.Audience = azureAdOptions?.ResourceId;
                 options.Authority = authority;

--- a/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
+++ b/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
@@ -12,8 +12,8 @@ public static class AuthenticationExtensions
             .GetSection(EntraAuthenticationOptions.SectionName)
             .Get<EntraAuthenticationOptions>();
         var azureAdOptions = configuration
-            .GetSection(AzureAdAuthenticationOptions.SectionName)
-            .Get<AzureAdAuthenticationOptions>();
+            .GetSection(B2CAuthenticationOptions.SectionName)
+            .Get<B2CAuthenticationOptions>();
         var authority = $"https://login.microsoftonline.com/{azureAdOptions?.TenantId}/v2.0";
 
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
+++ b/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
@@ -29,11 +29,12 @@ public static class AuthenticationExtensions
         });
 
         // Add authentication for Azure AD
-        services.AddAuthentication().AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
-        {
-            options.Authority = authority;
-            options.Audience = azureAdOptions?.Audience;
-        });
+        services.AddAuthentication()
+            .AddJwtBearer(x =>
+            {
+                x.Audience = azureAdOptions?.Audience;
+                x.Authority = authority;
+            });
 
         return services;
     }

--- a/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
+++ b/source/dotnet/Measurements.WebApi/Extensions/DependencyInjection/AuthenticationExtensions.cs
@@ -11,10 +11,10 @@ public static class AuthenticationExtensions
         var entraAuthenticationOptions = configuration
             .GetSection(EntraAuthenticationOptions.SectionName)
             .Get<EntraAuthenticationOptions>();
-        var azureAdOptions = configuration
+        var b2CAuthenticationOptions = configuration
             .GetSection(B2CAuthenticationOptions.SectionName)
             .Get<B2CAuthenticationOptions>();
-        var authority = $"https://login.microsoftonline.com/{azureAdOptions?.TenantId}/v2.0";
+        var authority = $"https://login.microsoftonline.com/{b2CAuthenticationOptions?.TenantId}/v2.0";
 
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
@@ -29,7 +29,7 @@ public static class AuthenticationExtensions
             })
             .AddJwtBearer("B2C", options =>
             {
-                options.Audience = azureAdOptions?.ResourceId;
+                options.Audience = b2CAuthenticationOptions?.ResourceId;
                 options.Authority = authority;
             });
 

--- a/source/dotnet/Measurements.WebApi/appsettings.Sample.json
+++ b/source/dotnet/Measurements.WebApi/appsettings.Sample.json
@@ -23,12 +23,7 @@
         "Issuer": "https://sts.windows.net/<tenant_id>/"
     },
     "AzureAd": {
-      "Instance": "https://login.microsoftonline.com/",
       "TenantId": "tenant_id",
-      "ClientId": "b2c_client_app_id",
-      "ResourceId": "b2c_backend_app_id",
-      "TokenValidationParameters": {
-        "RoleClaimType": "roles"
-      }
+      "ResourceId": "b2c_backend_app_id"
     }
 }

--- a/source/dotnet/Measurements.WebApi/appsettings.Sample.json
+++ b/source/dotnet/Measurements.WebApi/appsettings.Sample.json
@@ -22,7 +22,7 @@
         "ApplicationIdUri": "https://management.azure.com",
         "Issuer": "https://sts.windows.net/<tenant_id>/"
     },
-    "AzureAd": {
+    "B2CAuthentication": {
       "TenantId": "tenant_id",
       "ResourceId": "b2c_backend_app_id"
     }

--- a/source/dotnet/Measurements.WebApi/appsettings.Sample.json
+++ b/source/dotnet/Measurements.WebApi/appsettings.Sample.json
@@ -21,5 +21,14 @@
     "Auth": {
         "ApplicationIdUri": "https://management.azure.com",
         "Issuer": "https://sts.windows.net/<tenant_id>/"
+    },
+    "AzureAd": {
+      "Instance": "https://login.microsoftonline.com/",
+      "TenantId": "tenant_id",
+      "ClientId": "b2c_client_app_id",
+      "ResourceId": "b2c_backend_app_id",
+      "TokenValidationParameters": {
+        "RoleClaimType": "roles"
+      }
     }
 }


### PR DESCRIPTION
# Description

Allow for multiple issuers when authenticating with the MeasurementsApi. This is a temporary solution, allowing B2C to authorize. Later Azure Entra identities will be the only way to authenticate.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
