### PR TITLE
[MeasurementsApi] Temporarily reintroduce v2

### DIFF
--- a/source/dotnet/Measurements.WebApi/Controllers/MeasurementsController.cs
+++ b/source/dotnet/Measurements.WebApi/Controllers/MeasurementsController.cs
@@ -12,6 +12,7 @@ namespace Energinet.DataHub.Measurements.WebApi.Controllers;
 
 [ApiController]
 [Authorize(AuthenticationSchemes = $"{AuthenticationSchemas.Default},{AuthenticationSchemas.B2C}")]
+[ApiVersion(2.0, Deprecated = true)]
 [ApiVersion(3.0, Deprecated = true)]
 [ApiVersion(4.0)]
 [Route("v{v:apiVersion}/measurements")]
@@ -19,6 +20,7 @@ public class MeasurementsController(
     IMeasurementsHandler measurementsHandler, ILogger<MeasurementsController> logger, IJsonSerializer jsonSerializer)
     : ControllerBase
 {
+    [MapToApiVersion(2.0)]
     [MapToApiVersion(3.0)]
     [MapToApiVersion(4.0)]
     [HttpGet("forPeriod")]


### PR DESCRIPTION
# Description

An old version of MeasurementsClient using a two majors old version of MeasurementsApi is still in use in BFF:
![image](https://github.com/user-attachments/assets/18e6f29f-824f-40d7-9ddc-31bb57ac8190)

This PR temporarily reintroduces v2, until BFF is using the latest version of MeasurementsClient (v.8.0.0)