### PR TITLE
refac: Filter current_v1 by period in missing measurements log

### DIFF
--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/missing_measurements_log/domain/calculation.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/missing_measurements_log/domain/calculation.py
@@ -34,7 +34,9 @@ def execute(
     expected_measurement_counts = _get_expected_measurement_counts(
         metering_point_periods_df, time_zone, period_start_datetime, period_end_datetime
     )
-    actual_measurement_counts = _get_actual_measurement_counts(current_measurements, time_zone)
+    actual_measurement_counts = _get_actual_measurement_counts(
+        current_measurements, period_start_datetime, period_end_datetime, time_zone
+    )
 
     missing_measurements = _get_missing_measurements(
         expected_measurement_counts=expected_measurement_counts,

--- a/source/geh_calculated_measurements/src/geh_calculated_measurements/missing_measurements_log/domain/calculation.py
+++ b/source/geh_calculated_measurements/src/geh_calculated_measurements/missing_measurements_log/domain/calculation.py
@@ -114,11 +114,18 @@ def _get_expected_measurement_counts(
     return expected_measurement_counts
 
 
-def _get_actual_measurement_counts(current_measurements: CurrentMeasurements, time_zone: str) -> DataFrame:
+def _get_actual_measurement_counts(
+    current_measurements: CurrentMeasurements,
+    period_start_datetime: datetime,
+    period_end_datetime: datetime,
+    time_zone: str,
+) -> DataFrame:
     """Calculate the actual measurement counts grouped by metering point and date."""
-    current_measurements_df = current_measurements.df.where(
-        F.col(ContractColumnNames.observation_time).isNotNull()
-    ).where(F.col(ContractColumnNames.quality) != QuantityQuality.MISSING.value)
+    current_measurements_df = (
+        current_measurements.df.where(F.col(ContractColumnNames.observation_time) >= period_start_datetime)
+        .where(F.col(ContractColumnNames.observation_time) < period_end_datetime)
+        .where(F.col(ContractColumnNames.quality) != QuantityQuality.MISSING.value)
+    )
 
     current_measurements_df = convert_from_utc(current_measurements_df, time_zone)
 


### PR DESCRIPTION
# Description

We want to avoid doing transformations on the entire current_v1 data when we only want a limit time period.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
