### PR TITLE
chore: Run MeasurementsApi performance tests on API v5

### DIFF
--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithDailyAggregates.jmx
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithDailyAggregates.jmx
@@ -73,7 +73,7 @@
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/measurementsapi/v4/measurements/aggregatedByPeriod</stringProp>
+          <stringProp name="HTTPSampler.path">/measurementsapi/v5/measurements/aggregatedByPeriod</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithHourlyAggregates.jmx
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithHourlyAggregates.jmx
@@ -73,7 +73,7 @@
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/measurementsapi/v4/measurements/aggregatedByPeriod</stringProp>
+          <stringProp name="HTTPSampler.path">/measurementsapi/v5/measurements/aggregatedByPeriod</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithMonthlyAggregates.jmx
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithMonthlyAggregates.jmx
@@ -73,7 +73,7 @@
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/measurementsapi/v4/measurements/aggregatedByPeriod</stringProp>
+          <stringProp name="HTTPSampler.path">/measurementsapi/v5/measurements/aggregatedByPeriod</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithQuarterlyAggregates.jmx
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithQuarterlyAggregates.jmx
@@ -73,7 +73,7 @@
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/measurementsapi/v4/measurements/aggregatedByPeriod</stringProp>
+          <stringProp name="HTTPSampler.path">/measurementsapi/v5/measurements/aggregatedByPeriod</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithYearlyAggregates.jmx
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithYearlyAggregates.jmx
@@ -73,7 +73,7 @@
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/measurementsapi/v4/measurements/aggregatedByPeriod</stringProp>
+          <stringProp name="HTTPSampler.path">/measurementsapi/v5/measurements/aggregatedByPeriod</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/source/dotnet/Measurements.WebApi/Measurements.WebApi.csproj
+++ b/source/dotnet/Measurements.WebApi/Measurements.WebApi.csproj
@@ -21,8 +21,4 @@
       <ProjectReference Include="..\Measurements.Infrastructure\Measurements.Infrastructure.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Assets\PerformanceTest\" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
# Description

Run Performance tests on the latest MeasurementsApi version (v5)