### PR TITLE
tests: Decrease valid median of response times

### DIFF
--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithDailyAggregates.yaml
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithDailyAggregates.yaml
@@ -8,7 +8,7 @@ configurationFiles:
    - 'aggregatedByPeriodWithDailyAggregates.csv'
 failureCriteria:
   - percentage(error) > 1
-  - p50(response_time_ms) > 1200
+  - p50(response_time_ms) > 800
 autoStop:
   errorPercentage: 80
   timeWindow: 60

--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithHourlyAggregates.yaml
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithHourlyAggregates.yaml
@@ -8,7 +8,7 @@ configurationFiles:
    - 'aggregatedByPeriodWithHourlyAggregates.csv'
 failureCriteria:
   - percentage(error) > 1
-  - p50(response_time_ms) > 1300
+  - p50(response_time_ms) > 800
 autoStop:
   errorPercentage: 80
   timeWindow: 60

--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithMonthlyAggregates.yaml
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithMonthlyAggregates.yaml
@@ -8,7 +8,7 @@ configurationFiles:
    - 'aggregatedByPeriodWithMonthlyAggregates.csv'
 failureCriteria:
   - percentage(error) > 1
-  - p50(response_time_ms) > 1200
+  - p50(response_time_ms) > 800
 autoStop:
   errorPercentage: 80
   timeWindow: 60

--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithQuarterlyAggregates.yaml
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithQuarterlyAggregates.yaml
@@ -8,7 +8,7 @@ configurationFiles:
    - 'aggregatedByPeriodWithQuarterlyAggregates.csv'
 failureCriteria:
   - percentage(error) > 1
-  - p50(response_time_ms) > 1300
+  - p50(response_time_ms) > 800
 autoStop:
   errorPercentage: 80
   timeWindow: 60

--- a/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithYearlyAggregates.yaml
+++ b/source/dotnet/Measurements.WebApi/Assets/PerformanceTests/Aggregated/ByPeriod/aggregatedByPeriodWithYearlyAggregates.yaml
@@ -8,7 +8,7 @@ configurationFiles:
    - 'aggregatedByPeriodWithYearlyAggregates.csv'
 failureCriteria:
   - percentage(error) > 1
-  - p50(response_time_ms) > 1200
+  - p50(response_time_ms) > 800
 autoStop:
   errorPercentage: 80
   timeWindow: 60


### PR DESCRIPTION
# Description

We've seen consistently low median response times as a result of the last week of running the MeasurementsApi performance tests:
https://github.com/Energinet-DataHub/dh3-environments/actions/workflows/measurements-tests-scheduled.yml

To get notified if/when anything degrades the performance we decrease the valid median response times to 800ms.