### PR TITLE
Alter `current_sap_v1` view to only show orchestration type `migration`

### DIFF
--- a/source/core/src/core/databases/migrations/migration_scripts/20250607120000_alter_current_sap_v1_view.sql
+++ b/source/core/src/core/databases/migrations/migration_scripts/20250607120000_alter_current_sap_v1_view.sql
@@ -1,7 +1,3 @@
-DROP VIEW IF EXISTS {gold_database}.{gold_current_sap_v1}
-
-GO
-
 CREATE VIEW {gold_database}.{gold_current_sap_v1} AS
 WITH RankedRows AS (
     SELECT
@@ -9,8 +5,7 @@ WITH RankedRows AS (
         ROW_NUMBER() OVER (PARTITION BY metering_point_id, observation_time ORDER BY transaction_creation_datetime DESC) AS row_num
     FROM {gold_database}.{gold_measurements}
     WHERE
-        orchestration_type = "migration"
-        AND metering_point_id IS NOT NULL
+        metering_point_id IS NOT NULL
         AND observation_time IS NOT NULL
         AND quality IS NOT NULL    
         AND metering_point_type IS NOT NULL

--- a/source/core/tests/integration/features/gold_current_sap_view.feature
+++ b/source/core/tests/integration/features/gold_current_sap_view.feature
@@ -29,3 +29,24 @@ Feature: Current_sap_v1 Gold View
     Given a gold measurement where quantity is null
     When querying the current_sap_v1 gold view for that metering point
     Then the result should contain 1 rows
+
+  Scenario: View returns migration measurements
+    Given a gold migration measurements
+    When querying the current_sap_v1 gold view for that metering point
+    Then the result should contain 1 rows
+
+  Scenario: View does not return submitted measurements
+    Given a gold submitted measurements
+    When querying the current_sap_v1 gold view for that metering point
+    Then the result should contain 0 rows
+
+  Scenario: View does not return electrical_heating measurements
+    Given a gold electrical_heating measurements
+    When querying the current_sap_v1 gold view for that metering point
+    Then the result should contain 0 rows
+
+  Scenario: View does not return capacity_settlement measurements
+    Given a gold capacity_settlement measurements
+    When querying the current_sap_v1 gold view for that metering point
+    Then the result should contain 0 rows    
+        

--- a/source/core/tests/integration/step_definitions/test_gold_current_sap_view.py
+++ b/source/core/tests/integration/step_definitions/test_gold_current_sap_view.py
@@ -109,6 +109,31 @@ def _(spark, column):
     return mp_id
 
 
+@given(
+    "a gold {orchestration_type:d} measurements",
+    target_fixture="metering_point_id",
+)
+def _(spark, orchestration_type: str):
+    mp_id = identifier_helper.create_random_metering_point_id()
+    obs_time = datetime_helper.get_datetime()
+
+    data = (
+        GoldMeasurementsBuilder(spark)
+        .add_row(
+            orchestration_type=orchestration_type,
+            metering_point_id=mp_id,
+            observation_time=obs_time,
+            quantity=Decimal(100),
+            transaction_creation_datetime=datetime_helper.get_datetime(2021, 1, 1),
+            is_cancelled=False,
+        )
+        .build()
+    )
+
+    table_helper.append_to_table(data, GoldSettings().gold_database_name, GoldTableNames.gold_measurements)
+    return mp_id
+
+
 @when("accessing the current_sap_v1 gold view", target_fixture="actual_schema")
 def _(spark):
     return spark.table(f"{GoldSettings().gold_database_name}.{GoldViewNames.current_sap_v1}").schema


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->
Forgot to only return measurements with orchestration type `migration`.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
- https://github.com/Energinet-DataHub/team-volt/issues/1194